### PR TITLE
feat: show payment breakdown and petty cash

### DIFF
--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -130,6 +130,23 @@ function ManagementDashboard() {
                         if (parsedData.shawarma) {
                             parsedData.shawarma = computeShawarmaMetrics(parsedData.shawarma);
                         }
+                        if (parsedData.sales) {
+                            const revenueFields = [
+                                'cash_sales_qar',
+                                'card_sales_qar',
+                                'delivery_aggregator_1_qar',
+                                'delivery_aggregator_2_qar',
+                                'other_food_revenue',
+                                'beverage_revenue'
+                            ];
+                            parsedData.sales.total_revenue = revenueFields.reduce((sum, field) =>
+                                sum + (parseFloat(parsedData.sales[field]) || 0), 0);
+                            parsedData.sales.petty_cash_spent = parseFloat(parsedData.sales.petty_cash_spent) || 0;
+                            const totalFoodCost = parseFloat(parsedData.sales.total_food_cost) || 0;
+                            parsedData.sales.food_cost_percentage = parsedData.sales.total_revenue > 0
+                                ? (totalFoodCost / parsedData.sales.total_revenue) * 100
+                                : 0;
+                        }
                         setDashboardData(parsedData);
                         generateAlerts(parsedData);
                         
@@ -293,7 +310,23 @@ function ManagementDashboard() {
         return children;
     };
 
- 
+    const paymentBreakdown = React.useMemo(() => {
+        if (!dashboardData || !dashboardData.sales) return [];
+        const fields = [
+            { key: 'cash_sales_qar', label: 'Cash' },
+            { key: 'card_sales_qar', label: 'Card' },
+            { key: 'delivery_aggregator_1_qar', label: 'Aggregator 1' },
+            { key: 'delivery_aggregator_2_qar', label: 'Aggregator 2' },
+            { key: 'other_food_revenue', label: 'Other Food' },
+            { key: 'beverage_revenue', label: 'Beverages' }
+        ];
+        const total = dashboardData.sales.total_revenue || 0;
+        return fields.map(f => {
+            const value = parseFloat(dashboardData.sales[f.key]) || 0;
+            return { label: f.label, value, percent: total > 0 ? (value / total) * 100 : 0 };
+        });
+    }, [dashboardData]);
+
 
     return (
         <div className="space-y-6">
@@ -367,7 +400,7 @@ function ManagementDashboard() {
             )}
 
             {/* Key Metrics with individual loading */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
                 {/* Shawarma Profitability */}
                 <LoadingCard isLoading={cardLoading.metrics}>
                     <div className="bg-white rounded-lg shadow p-6">
@@ -455,6 +488,22 @@ function ManagementDashboard() {
                         <div className="mt-4 text-sm text-gray-500">
                             Orders: {dashboardData && dashboardData.sales && dashboardData.sales.total_orders ? 
                                 dashboardData.sales.total_orders : 'N/A'}
+                        </div>
+                    </div>
+                </LoadingCard>
+
+                {/* Petty Cash Spent */}
+                <LoadingCard isLoading={cardLoading.metrics}>
+                    <div className="bg-white rounded-lg shadow p-6">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm font-medium text-gray-600">Petty Cash Spent</p>
+                                <p className="text-2xl font-bold text-purple-600">
+                                    {dashboardData && dashboardData.sales ?
+                                        `${dashboardData.sales.petty_cash_spent.toFixed(2)} QAR` : 'N/A'}
+                                </p>
+                            </div>
+                            <div className="text-3xl">🧾</div>
                         </div>
                     </div>
                 </LoadingCard>
@@ -557,7 +606,7 @@ function ManagementDashboard() {
                                 <div className="grid grid-cols-2 gap-4 text-sm">
                                     <div>
                                         <span className="text-gray-600">Total Revenue:</span>
-                                        <p className="font-medium text-blue-600">{dashboardData.sales.total_revenue ? 
+                                        <p className="font-medium text-blue-600">{dashboardData.sales.total_revenue ?
                                             dashboardData.sales.total_revenue.toFixed(2) : 'N/A'} QAR</p>
                                     </div>
                                     <div>
@@ -586,12 +635,35 @@ function ManagementDashboard() {
                                     <div>
                                         <span className="text-gray-600">Average Order Value:</span>
                                         <p className="font-medium">
-                                            {dashboardData.sales.total_orders && dashboardData.sales.total_revenue && dashboardData.sales.total_orders > 0 ? 
-                                                (dashboardData.sales.total_revenue / dashboardData.sales.total_orders).toFixed(2) : 'N/A'} QAR
-                                        </p>
+                                        {dashboardData.sales.total_orders && dashboardData.sales.total_revenue && dashboardData.sales.total_orders > 0 ?
+                                            (dashboardData.sales.total_revenue / dashboardData.sales.total_orders).toFixed(2) : 'N/A'} QAR
+                                    </p>
+                                </div>
+                            </div>
+
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-6 border-t pt-4">
+                                    <div>
+                                        <h4 className="font-medium text-gray-700 mb-2">Payment Channels</h4>
+                                        <div className="space-y-2">
+                                            {paymentBreakdown.map((item, idx) => (
+                                                <div key={idx}>
+                                                    <div className="flex justify-between text-sm">
+                                                        <span className="text-gray-600">{item.label}:</span>
+                                                        <span className="font-medium">{item.value.toFixed(2)} QAR</span>
+                                                    </div>
+                                                    <div className="w-full bg-gray-200 rounded h-2 mt-1">
+                                                        <div className="h-2 rounded bg-olive-600" style={{width: `${item.percent.toFixed(1)}%`}}></div>
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                    <div className="flex flex-col justify-center">
+                                        <h4 className="font-medium text-gray-700 mb-2">Petty Cash Spent</h4>
+                                        <p className="text-2xl font-bold text-purple-600">{dashboardData.sales.petty_cash_spent.toFixed(2)} QAR</p>
                                     </div>
                                 </div>
-                                
+
                                 <div className="border-t pt-4">
                                     <h4 className="font-medium text-gray-700 mb-2">Performance Indicators</h4>
                                     <div className="space-y-2">
@@ -609,7 +681,7 @@ function ManagementDashboard() {
                                         <div className="flex justify-between items-center">
                                             <span className="text-sm text-gray-600">Profit Margin:</span>
                                             <span className="text-sm font-medium text-green-600">
-                                                {dashboardData.sales.food_cost_percentage ? 
+                                                {dashboardData.sales.food_cost_percentage ?
                                                     (100 - dashboardData.sales.food_cost_percentage).toFixed(1) : 'N/A'}%
                                             </span>
                                         </div>

--- a/app-bundle.html
+++ b/app-bundle.html
@@ -55,27 +55,45 @@ function HomeTab({ onTabChange }) {
         return orderDate.toDateString() === today;
     }) : [];
 
-    const todayRevenue = todayOrders.reduce((sum, order) => sum + (order.total_amount || 0), 0);
-    const averageOrderValue = todayOrders.length > 0 ? todayRevenue / todayOrders.length : 0;
-    
+    const todaySales = (data.dailySales && data.dailySales.find) ? data.dailySales.find(sales =>
+        new Date(sales.sales_date).toDateString() === today
+    ) : null;
+
+    const revenueFields = [
+        { key: 'cash_sales_qar', label: 'Cash' },
+        { key: 'card_sales_qar', label: 'Card' },
+        { key: 'delivery_aggregator_1_qar', label: 'Aggregator 1' },
+        { key: 'delivery_aggregator_2_qar', label: 'Aggregator 2' },
+        { key: 'other_food_revenue', label: 'Other Food' },
+        { key: 'beverage_revenue', label: 'Beverages' }
+    ];
+
+    const todayRevenue = todaySales ? revenueFields.reduce((sum, f) => sum + (parseFloat(todaySales[f.key]) || 0), 0) : 0;
+    const totalFoodCost = todaySales ? parseFloat(todaySales.total_food_cost) || 0 : 0;
+    const foodCostPercentage = todayRevenue > 0 ? (totalFoodCost / todayRevenue) * 100 : 0;
+    const totalOrders = todaySales && todaySales.total_orders ? parseInt(todaySales.total_orders) || 0 : todayOrders.length;
+    const averageOrderValue = totalOrders > 0 ? todayRevenue / totalOrders : 0;
+
+    const paymentBreakdown = revenueFields.map(f => {
+        const value = todaySales ? parseFloat(todaySales[f.key]) || 0 : 0;
+        return { label: f.label, value, percent: todayRevenue > 0 ? (value / todayRevenue) * 100 : 0 };
+    });
+
+    const pettyCash = todaySales ? parseFloat(todaySales.petty_cash_spent) || 0 : 0;
+
     const activeEmployees = (data.employees && data.employees.filter) ? data.employees.filter(emp => emp.active === true).length : 0;
 
-    const lowStockItems = (data.ingredients && data.ingredients.filter) ? data.ingredients.filter(ingredient => 
+    const lowStockItems = (data.ingredients && data.ingredients.filter) ? data.ingredients.filter(ingredient =>
         ingredient.quantity <= ingredient.min_stock
     ).length : 0;
 
-    const pendingOrders = todayOrders.filter(order => 
+    const pendingOrders = todayOrders.filter(order =>
         order.status === 'pending' || order.status === 'in_progress'
     ).length || 0;
 
     // Get today's shawarma data - FIXED: Removed optional chaining
-    const todayShawarma = (data.dailyShawarmaStack && data.dailyShawarmaStack.find) ? data.dailyShawarmaStack.find(stack => 
+    const todayShawarma = (data.dailyShawarmaStack && data.dailyShawarmaStack.find) ? data.dailyShawarmaStack.find(stack =>
         new Date(stack.date).toDateString() === today
-    ) : null;
-
-    // Get today's sales data - FIXED: Removed optional chaining
-    const todaySales = (data.dailySales && data.dailySales.find) ? data.dailySales.find(sales => 
-        new Date(sales.sales_date).toDateString() === today
     ) : null;
 
     return (
@@ -105,7 +123,7 @@ function HomeTab({ onTabChange }) {
                         <div className="flex-1">
                             <p className="text-sm font-medium text-gray-600">Today's Revenue</p>
                             <p className="text-2xl font-bold text-blue-600">{todayRevenue.toFixed(2)} QAR</p>
-                            <p className="text-xs text-gray-500">{todayOrders.length} orders</p>
+                            <p className="text-xs text-gray-500">{totalOrders} orders</p>
                         </div>
                         <div className="text-3xl text-blue-500">💰</div>
                     </div>
@@ -116,9 +134,9 @@ function HomeTab({ onTabChange }) {
                         <div className="flex-1">
                             <p className="text-sm font-medium text-gray-600">Food Cost %</p>
                             <p className={`text-2xl font-bold ${
-                                (todaySales && todaySales.food_cost_percentage > 25) ? 'text-red-600' : 'text-green-600'
+                                foodCostPercentage > 25 ? 'text-red-600' : 'text-green-600'
                             }`}>
-                                {(todaySales && todaySales.food_cost_percentage) ? todaySales.food_cost_percentage.toFixed(1) : 'N/A'}%
+                                {todayRevenue > 0 ? foodCostPercentage.toFixed(1) : 'N/A'}%
                             </p>
                             <p className="text-xs text-gray-500">Target: &lt; 25%</p>
                         </div>
@@ -209,6 +227,34 @@ function HomeTab({ onTabChange }) {
                 </div>
             </div>
 
+            {todaySales && (
+            <div className="bg-white rounded-lg shadow-md p-6">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">Payment Breakdown & Petty Cash</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div>
+                        <h4 className="font-medium text-gray-700 mb-2">Payment Channels</h4>
+                        <div className="space-y-2">
+                            {paymentBreakdown.map((item, index) => (
+                                <div key={index}>
+                                    <div className="flex justify-between text-sm">
+                                        <span className="text-gray-600">{item.label}</span>
+                                        <span className="font-medium">{item.value.toFixed(2)} QAR</span>
+                                    </div>
+                                    <div className="w-full bg-gray-200 rounded h-2 mt-1">
+                                        <div className="h-2 rounded bg-olive-600" style={{width: `${item.percent.toFixed(1)}%`}}></div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                    <div className="flex flex-col justify-center">
+                        <p className="text-sm font-medium text-gray-600">Petty Cash Spent</p>
+                        <p className="text-3xl font-bold text-purple-600">{pettyCash.toFixed(2)} QAR</p>
+                    </div>
+                </div>
+            </div>
+            )}
+
             {/* Quick Actions */}
             <div className="bg-white rounded-lg shadow-md p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">Quick Actions</h3>
@@ -292,8 +338,8 @@ function HomeTab({ onTabChange }) {
                             <div className="p-3 bg-green-50 rounded-lg">
                                 <p className="font-medium text-green-800">Food Cost Control</p>
                                 <p className="text-sm text-green-600">
-                                    Food Cost: {(todaySales.food_cost_percentage) ? todaySales.food_cost_percentage.toFixed(1) : 'N/A'}% 
-                                    {todaySales.food_cost_percentage < 25 ? ' (Excellent!)' : ' (Monitor)'}
+                                    Food Cost: {todayRevenue > 0 ? foodCostPercentage.toFixed(1) : 'N/A'}%
+                                    {foodCostPercentage < 25 ? ' (Excellent!)' : ' (Monitor)'}
                                 </p>
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- compute sales revenue and food-cost metrics using detailed payment channels
- surface petty cash spending and payment breakdown on management and home dashboards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891fb652d8c8325ae9383a6bda32b08