### PR TITLE
Add translations for daily sales metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,18 @@
         dailySales: "Daily Sales",
         totalDailyRevenue: "Total Daily Revenue (QAR)",
         shawarmaRevenue: "Shawarma Revenue (QAR)",
-        
+        cashSales: "Cash Sales (QAR)",
+        cardSales: "Card Sales (QAR)",
+        deliveryAggregator1: "Delivery Aggregator 1 (QAR)",
+        deliveryAggregator2: "Delivery Aggregator 2 (QAR)",
+        otherFoodRevenue: "Other Food Revenue (QAR)",
+        beverageRevenue: "Beverage Revenue (QAR)",
+        pettyCashTotal: "Petty Cash Total (QAR)",
+        totalFoodCost: "Total Food Cost (QAR)",
+        foodCostPercentage: "Food Cost Percentage (%)",
+        totalOrders: "Total Orders",
+        salesNotes: "Sales Notes",
+
         // Notes Section
         dailyNotes: "Daily Notes",
         anyObservations: "Any observations or comments about today's operations...",
@@ -324,7 +335,18 @@
         dailySales: "المبيعات اليومية",
         totalDailyRevenue: "إجمالي الإيرادات اليومية (ريال)",
         shawarmaRevenue: "إيرادات الشاورما (ريال)",
-        
+        cashSales: "مبيعات نقدية (ريال)",
+        cardSales: "مبيعات البطاقات (ريال)",
+        deliveryAggregator1: "مبيعات منصة التوصيل 1 (ريال)",
+        deliveryAggregator2: "مبيعات منصة التوصيل 2 (ريال)",
+        otherFoodRevenue: "إيرادات الطعام الأخرى (ريال)",
+        beverageRevenue: "إيرادات المشروبات (ريال)",
+        pettyCashTotal: "إجمالي المصروفات النثرية (ريال)",
+        totalFoodCost: "إجمالي تكلفة الطعام (ريال)",
+        foodCostPercentage: "نسبة تكلفة الطعام (%)",
+        totalOrders: "إجمالي الطلبات",
+        salesNotes: "ملاحظات المبيعات",
+
         // Notes Section
         dailyNotes: "ملاحظات يومية",
         anyObservations: "أي ملاحظات أو تعليقات حول عمليات اليوم...",


### PR DESCRIPTION
## Summary
- Add English translations for new daily sales fields like cash and card sales, delivery aggregators, other revenues, cost metrics, and notes.
- Add Arabic equivalents for the same daily sales labels.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891fb5775bc83259c851282375dc724