### PR TITLE
feat: expand sales tracking and dynamic inventory

### DIFF
--- a/BilingualEmployeeDailyEntryTab.html
+++ b/BilingualEmployeeDailyEntryTab.html
@@ -18,6 +18,11 @@ function BilingualEmployeeDailyEntryTab() {
     sales: {
       total_revenue: '',
       shawarma_revenue: '',
+      other_food_revenue: '',
+      cash_sales: '',
+      card_sales: '',
+      delivery_aggregator_1: '',
+      delivery_aggregator_2: '',
       petty_cash_total: '',
       pettyCashDetails: []
     },
@@ -39,6 +44,13 @@ function BilingualEmployeeDailyEntryTab() {
       })
       .getDailyItems();
   }, []);
+
+  React.useEffect(() => {
+    setFormData(prev => {
+      const other = (parseFloat(prev.sales.total_revenue) || 0) - (parseFloat(prev.sales.shawarma_revenue) || 0);
+      return { ...prev, sales: { ...prev.sales, other_food_revenue: other.toFixed(2) } };
+    });
+  }, [formData.sales.total_revenue, formData.sales.shawarma_revenue]);
 
   const handleInventoryChange = (id, field, value) => {
     setFormData(prev => ({
@@ -215,6 +227,68 @@ function BilingualEmployeeDailyEntryTab() {
               }))}
               className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
               required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">{t('otherFoodRevenueQAR')}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.other_food_revenue}
+              readOnly
+              className="w-full p-2 border rounded bg-gray-100"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">{t('cashSalesQAR')}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.cash_sales}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, cash_sales: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">{t('cardSalesQAR')}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.card_sales}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, card_sales: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">{t('deliveryAggregator1QAR')}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.delivery_aggregator_1}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, delivery_aggregator_1: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">{t('deliveryAggregator2QAR')}</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.delivery_aggregator_2}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, delivery_aggregator_2: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
             />
           </div>
         </div>

--- a/Code.gs
+++ b/Code.gs
@@ -918,17 +918,33 @@ function saveSalesData(entryData, entryDate, employeeId) {
   const salesData = entryData.sales || {};
 
   const salesId = Utilities.getUuid();
+
+  const totalRevenue = parseFloat(salesData.total_revenue) || 0;
+  const shawarmaRevenue = parseFloat(salesData.shawarma_revenue) || 0;
+  const otherFoodRevenue = isNaN(parseFloat(salesData.other_food_revenue))
+    ? totalRevenue - shawarmaRevenue
+    : parseFloat(salesData.other_food_revenue);
+  const cashSales = parseFloat(salesData.cash_sales) || 0;
+  const cardSales = parseFloat(salesData.card_sales) || 0;
+  const delivery1 = parseFloat(salesData.delivery_aggregator_1) || 0;
+  const delivery2 = parseFloat(salesData.delivery_aggregator_2) || 0;
+  let pettyCashTotal = parseFloat(salesData.petty_cash_total) || 0;
+
+  if (Array.isArray(salesData.pettyCashDetails)) {
+    pettyCashTotal = salesData.pettyCashDetails.reduce((sum, d) => sum + (parseFloat(d.amount) || 0), 0);
+  }
+
   const row = [
     salesId,
     entryDate,
-    parseFloat(salesData.total_revenue) || 0,
-    parseFloat(salesData.shawarma_revenue) || 0,
-    parseFloat(salesData.other_food_revenue) || 0,
-    parseFloat(salesData.cash_sales) || 0,
-    parseFloat(salesData.card_sales) || 0,
-    parseFloat(salesData.delivery_aggregator_1) || 0,
-    parseFloat(salesData.delivery_aggregator_2) || 0,
-    parseFloat(salesData.petty_cash_total) || 0,
+    totalRevenue,
+    shawarmaRevenue,
+    otherFoodRevenue,
+    cashSales,
+    cardSales,
+    delivery1,
+    delivery2,
+    pettyCashTotal,
     salesData.notes || '',
     employeeId,
     new Date(),

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -17,6 +17,11 @@ function DailyEntryTab() {
     sales: {
       total_revenue: '',
       shawarma_revenue: '',
+      other_food_revenue: '',
+      cash_sales: '',
+      card_sales: '',
+      delivery_aggregator_1: '',
+      delivery_aggregator_2: '',
       petty_cash_total: '',
       pettyCashDetails: []
     },
@@ -38,6 +43,13 @@ function DailyEntryTab() {
       })
       .getDailyItems();
   }, []);
+
+  React.useEffect(() => {
+    setFormData(prev => {
+      const other = (parseFloat(prev.sales.total_revenue) || 0) - (parseFloat(prev.sales.shawarma_revenue) || 0);
+      return { ...prev, sales: { ...prev.sales, other_food_revenue: other.toFixed(2) } };
+    });
+  }, [formData.sales.total_revenue, formData.sales.shawarma_revenue]);
 
   const handleInventoryChange = (id, field, value) => {
     setFormData(prev => ({
@@ -214,6 +226,68 @@ function DailyEntryTab() {
               }))}
               className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
               required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Other Food Revenue (QAR)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.other_food_revenue}
+              readOnly
+              className="w-full p-2 border rounded bg-gray-100"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Cash Sales (QAR)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.cash_sales}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, cash_sales: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Card Sales (QAR)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.card_sales}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, card_sales: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Delivery Aggregator 1 (QAR)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.delivery_aggregator_1}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, delivery_aggregator_1: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Delivery Aggregator 2 (QAR)</label>
+            <input
+              type="number"
+              step="0.01"
+              value={formData.sales.delivery_aggregator_2}
+              onChange={e => setFormData(prev => ({
+                ...prev,
+                sales: { ...prev.sales, delivery_aggregator_2: e.target.value }
+              }))}
+              className="w-full p-2 border rounded focus:ring-2 focus:ring-olive-500"
             />
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -163,6 +163,14 @@
         dailySales: "Daily Sales",
         totalDailyRevenue: "Total Daily Revenue (QAR)",
         shawarmaRevenue: "Shawarma Revenue (QAR)",
+        totalDailyRevenueQAR: "Total Daily Revenue (QAR)",
+        shawarmaRevenueQAR: "Shawarma Revenue (QAR)",
+        otherFoodRevenueQAR: "Other Food Revenue (QAR)",
+        cashSalesQAR: "Cash Sales (QAR)",
+        cardSalesQAR: "Card Sales (QAR)",
+        deliveryAggregator1QAR: "Delivery Aggregator 1 (QAR)",
+        deliveryAggregator2QAR: "Delivery Aggregator 2 (QAR)",
+        pettyCashTotalQAR: "Petty Cash Total (QAR)",
         
         // Notes Section
         dailyNotes: "Daily Notes",
@@ -324,6 +332,14 @@
         dailySales: "المبيعات اليومية",
         totalDailyRevenue: "إجمالي الإيرادات اليومية (ريال)",
         shawarmaRevenue: "إيرادات الشاورما (ريال)",
+        totalDailyRevenueQAR: "إجمالي الإيرادات اليومية (ريال)",
+        shawarmaRevenueQAR: "إيرادات الشاورما (ريال)",
+        otherFoodRevenueQAR: "إيرادات الأطعمة الأخرى (ريال)",
+        cashSalesQAR: "المبيعات النقدية (ريال)",
+        cardSalesQAR: "مبيعات البطاقات (ريال)",
+        deliveryAggregator1QAR: "مجمّع التوصيل 1 (ريال)",
+        deliveryAggregator2QAR: "مجمّع التوصيل 2 (ريال)",
+        pettyCashTotalQAR: "إجمالي المصاريف النثرية (ريال)",
         
         // Notes Section
         dailyNotes: "ملاحظات يومية",


### PR DESCRIPTION
## Summary
- make daily inventory snapshot dynamic by category with closing quantity and notes
- add detailed sales inputs including other food revenue, payment types, and delivery aggregators
- auto-calc petty cash totals with modal pop-up and persist expanded sales data

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68939e342f9c8325b1c511d8b75d8c44