### PR TITLE
Fix management dashboard errors and update React root

### DIFF
--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -167,8 +167,14 @@ function ManagementDashboard() {
 
                         google.script.run
                             .withSuccessHandler(report => {
-                                setVarianceReport(report.variance);
-                                setAlerts(prev => [...prev, ...report.alerts]);
+                                // Handle cases where the Apps Script returns null or
+                                // doesn't include the expected variance data
+                                if (report && report.variance) {
+                                    setVarianceReport(report.variance);
+                                }
+                                if (report && report.alerts) {
+                                    setAlerts(prev => [...prev, ...report.alerts]);
+                                }
                             })
                             .getVarianceReport(dateParam);
                     } catch (parseError) {

--- a/index.html
+++ b/index.html
@@ -1544,21 +1544,21 @@ function DailyEntryTab({ employeeSession }) {
             return children;
         }
 
-        // Initialize the unified app
-        window.initializeRestaurantApp = function() {
-            console.log("Initializing unified restaurant React app...");
-            try {
-                ReactDOM.render(
-                    React.createElement(ErrorBoundary, null, 
-                        React.createElement(App)
-                    ), 
-                    document.getElementById('root')
-                );
-                console.log("Unified restaurant app rendered successfully");
-            } catch (error) {
-                console.error("Error rendering unified restaurant app:", error);
-            }
-        };
+         // Initialize the unified app
+         window.initializeRestaurantApp = function() {
+             console.log("Initializing unified restaurant React app...");
+             try {
+                 const root = ReactDOM.createRoot(document.getElementById('root'));
+                 root.render(
+                     React.createElement(ErrorBoundary, null,
+                         React.createElement(App)
+                     )
+                 );
+                 console.log("Unified restaurant app rendered successfully");
+             } catch (error) {
+                 console.error("Error rendering unified restaurant app:", error);
+             }
+         };
 
         console.log("Unified restaurant app components defined");
     </script>


### PR DESCRIPTION
## Summary
- Guard variance report handling when Apps Script returns null
- Use React 18 `createRoot` API instead of deprecated `ReactDOM.render`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b2d08d408325927c3944ce4572de