### PR TITLE
Prevent premature dashboard fetch and sanitize sales metrics

### DIFF
--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -119,7 +119,9 @@ function ManagementDashboard() {
     };
 
     const loadDashboardData = async (customDateOverride = null) => {
-        const effectiveCustomDate = customDateOverride ?? customDate;
+        const effectiveCustomDate = customDateOverride !== null && customDateOverride !== undefined
+            ? customDateOverride
+            : customDate;
 
         if (selectedPeriod === 'custom' && !effectiveCustomDate) {
             return;

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -14,6 +14,7 @@ function ManagementDashboard() {
         sales: true,
         inventory: true
     });
+    const [lastLoadedCustomDate, setLastLoadedCustomDate] = React.useState('');
     const [showDataStatus, setShowDataStatus] = React.useState(false);
     const [showDebugData, setShowDebugData] = React.useState(false);
 
@@ -197,6 +198,9 @@ function ManagementDashboard() {
                         }
 
                         setDashboardData(parsedData);
+                        if (selectedPeriod === 'custom' && customDate) {
+                            setLastLoadedCustomDate(customDate);
+                        }
                         generateAlerts(parsedData);
 
                         setLoading(false);
@@ -772,6 +776,27 @@ function ManagementDashboard() {
 
  
 
+    const isDashboardBusy = () => (
+        loading ||
+        cardLoading.metrics ||
+        cardLoading.shawarma ||
+        cardLoading.sales ||
+        cardLoading.inventory
+    );
+
+    const handleCustomDateBlur = (event) => {
+        if (selectedPeriod !== 'custom') return;
+
+        const value = event.target.value;
+        if (!value) return;
+        if (isDashboardBusy()) return;
+        if (value === lastLoadedCustomDate) return;
+
+        // Use the event value to ensure we load the exact date just chosen
+        setCustomDate(value);
+        loadDashboardData();
+    };
+
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -789,6 +814,7 @@ function ManagementDashboard() {
                                 const newPeriod = e.target.value;
                                 setSelectedPeriod(newPeriod);
                                 setCustomDate('');
+                                setLastLoadedCustomDate('');
                             }}
                             className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                         >
@@ -805,6 +831,7 @@ function ManagementDashboard() {
                                 type="date"
                                 value={customDate}
                                 onChange={e => setCustomDate(e.target.value)}
+                                onBlur={handleCustomDateBlur}
                                 className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                             />
                         )}

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -17,6 +17,7 @@ function ManagementDashboard() {
     const [lastLoadedCustomDate, setLastLoadedCustomDate] = React.useState('');
     const [pendingCustomDate, setPendingCustomDate] = React.useState('');
     const [isCustomPickerOpen, setIsCustomPickerOpen] = React.useState(false);
+    const [customDateDirty, setCustomDateDirty] = React.useState(false);
     const [showDataStatus, setShowDataStatus] = React.useState(false);
     const [showDebugData, setShowDebugData] = React.useState(false);
 
@@ -125,8 +126,14 @@ function ManagementDashboard() {
             ? customDateOverride
             : customDate;
 
-        if (selectedPeriod === 'custom' && !effectiveCustomDate) {
-            return;
+        const hasCustomDate = Boolean(effectiveCustomDate);
+        const parsedCustomDate = hasCustomDate ? new Date(effectiveCustomDate) : null;
+        const isValidCustomDate = parsedCustomDate && !isNaN(parsedCustomDate.getTime());
+
+        if (selectedPeriod === 'custom') {
+            if (!hasCustomDate || !isValidCustomDate) {
+                return;
+            }
         }
 
         if (dashboardData) {
@@ -145,7 +152,7 @@ function ManagementDashboard() {
             const formatISO = (d) => d.toISOString().split('T')[0];
 
             if (selectedPeriod === 'custom' && effectiveCustomDate) {
-                dateParam = formatISO(new Date(effectiveCustomDate));
+                dateParam = formatISO(parsedCustomDate);
             } else if (selectedPeriod === 'today') {
                 dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'yesterday') {
@@ -790,15 +797,28 @@ function ManagementDashboard() {
         cardLoading.inventory
     );
 
-    const commitCustomDateSelection = (value) => {
+    const isValidDateValue = (value) => {
+        if (!value) return false;
+        const parsed = new Date(value);
+        return !isNaN(parsed.getTime());
+    };
+
+    const commitCustomDateSelection = (value, options = {}) => {
         const resolvedDate = typeof value === 'string' ? value : pendingCustomDate;
+        const allowDuringPicker = options.allowDuringPicker === true;
+        const requireDirty = options.requireDirty === true;
 
         if (selectedPeriod !== 'custom') return;
-        if (!resolvedDate) return;
-        if (isCustomPickerOpen) return;
+        if (!isValidDateValue(resolvedDate)) return;
+        if (requireDirty && !customDateDirty) return;
+        if (!allowDuringPicker && isCustomPickerOpen) return;
         if (isDashboardBusy()) return;
-        if (resolvedDate === lastLoadedCustomDate) return;
+        if (resolvedDate === lastLoadedCustomDate) {
+            setCustomDateDirty(false);
+            return;
+        }
 
+        setCustomDateDirty(false);
         loadDashboardData(resolvedDate);
     };
 
@@ -806,11 +826,12 @@ function ManagementDashboard() {
         const value = event.target.value;
         setCustomDate(value);
         setPendingCustomDate(value);
+        setCustomDateDirty(true);
 
-        // If the picker is already closed (e.g., keyboard entry), commit immediately
-        if (!isCustomPickerOpen) {
-            commitCustomDateSelection(value);
-        }
+        // Commit immediately when a new date is chosen, even if the native picker
+        // keeps the input focused. This only fires when the value actually changes
+        // (not while navigating the calendar).
+        commitCustomDateSelection(value, { allowDuringPicker: true });
     };
 
     return (
@@ -833,6 +854,7 @@ function ManagementDashboard() {
                                 setLastLoadedCustomDate('');
                                 setPendingCustomDate('');
                                 setIsCustomPickerOpen(false);
+                                setCustomDateDirty(false);
                             }}
                             className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                         >
@@ -852,7 +874,7 @@ function ManagementDashboard() {
                                 onFocus={() => setIsCustomPickerOpen(true)}
                                 onBlur={() => {
                                     setIsCustomPickerOpen(false);
-                                    commitCustomDateSelection();
+                                    commitCustomDateSelection(undefined, { requireDirty: true });
                                 }}
                                 className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                             />

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -118,8 +118,10 @@ function ManagementDashboard() {
         return 1.0;
     };
 
-    const loadDashboardData = async () => {
-        if (selectedPeriod === 'custom' && !customDate) {
+    const loadDashboardData = async (customDateOverride = null) => {
+        const effectiveCustomDate = customDateOverride ?? customDate;
+
+        if (selectedPeriod === 'custom' && !effectiveCustomDate) {
             return;
         }
 
@@ -138,8 +140,8 @@ function ManagementDashboard() {
             let dateParam = null;
             const formatISO = (d) => d.toISOString().split('T')[0];
 
-            if (selectedPeriod === 'custom' && customDate) {
-                dateParam = formatISO(new Date(customDate));
+            if (selectedPeriod === 'custom' && effectiveCustomDate) {
+                dateParam = formatISO(new Date(effectiveCustomDate));
             } else if (selectedPeriod === 'today') {
                 dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'yesterday') {
@@ -198,8 +200,8 @@ function ManagementDashboard() {
                         }
 
                         setDashboardData(parsedData);
-                        if (selectedPeriod === 'custom' && customDate) {
-                            setLastLoadedCustomDate(customDate);
+                        if (selectedPeriod === 'custom' && effectiveCustomDate) {
+                            setLastLoadedCustomDate(effectiveCustomDate);
                         }
                         generateAlerts(parsedData);
 
@@ -784,17 +786,17 @@ function ManagementDashboard() {
         cardLoading.inventory
     );
 
-    const handleCustomDateBlur = (event) => {
-        if (selectedPeriod !== 'custom') return;
-
+    const handleCustomDateChange = (event) => {
         const value = event.target.value;
+        setCustomDate(value);
+
+        if (selectedPeriod !== 'custom') return;
         if (!value) return;
         if (isDashboardBusy()) return;
         if (value === lastLoadedCustomDate) return;
 
-        // Use the event value to ensure we load the exact date just chosen
-        setCustomDate(value);
-        loadDashboardData();
+        // Trigger the load immediately when the picker commits a new date
+        loadDashboardData(value);
     };
 
     return (
@@ -830,8 +832,7 @@ function ManagementDashboard() {
                             <input
                                 type="date"
                                 value={customDate}
-                                onChange={e => setCustomDate(e.target.value)}
-                                onBlur={handleCustomDateBlur}
+                                onChange={handleCustomDateChange}
                                 className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                             />
                         )}

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -14,20 +14,14 @@ function ManagementDashboard() {
         sales: true,
         inventory: true
     });
-    const [lastLoadedCustomDate, setLastLoadedCustomDate] = React.useState('');
-    const [pendingCustomDate, setPendingCustomDate] = React.useState('');
-    const [isCustomPickerOpen, setIsCustomPickerOpen] = React.useState(false);
-    const [customDateDirty, setCustomDateDirty] = React.useState(false);
     const [showDataStatus, setShowDataStatus] = React.useState(false);
     const [showDebugData, setShowDebugData] = React.useState(false);
 
     React.useEffect(() => {
-        // Only auto-load for non-custom periods. Custom dates should be fetched
-        // explicitly (e.g., via the Refresh button) after the user commits a date
-        // selection to avoid triggering requests while navigating the calendar.
-        if (selectedPeriod === 'custom') return;
-        loadDashboardData();
-    }, [selectedPeriod]);
+        if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
+            loadDashboardData();
+        }
+    }, [selectedPeriod, customDate]);
 
     const getAcceptableRemainingRange = (stackWeightKg) => {
         return {
@@ -121,21 +115,7 @@ function ManagementDashboard() {
         return 1.0;
     };
 
-    const loadDashboardData = async (customDateOverride = null) => {
-        const effectiveCustomDate = customDateOverride !== null && customDateOverride !== undefined
-            ? customDateOverride
-            : customDate;
-
-        const hasCustomDate = Boolean(effectiveCustomDate);
-        const parsedCustomDate = hasCustomDate ? new Date(effectiveCustomDate) : null;
-        const isValidCustomDate = parsedCustomDate && !isNaN(parsedCustomDate.getTime());
-
-        if (selectedPeriod === 'custom') {
-            if (!hasCustomDate || !isValidCustomDate) {
-                return;
-            }
-        }
-
+    const loadDashboardData = async () => {
         if (dashboardData) {
             setCardLoading({
                 metrics: true,
@@ -151,8 +131,8 @@ function ManagementDashboard() {
             let dateParam = null;
             const formatISO = (d) => d.toISOString().split('T')[0];
 
-            if (selectedPeriod === 'custom' && effectiveCustomDate) {
-                dateParam = formatISO(parsedCustomDate);
+            if (selectedPeriod === 'custom' && customDate) {
+                dateParam = formatISO(new Date(customDate));
             } else if (selectedPeriod === 'today') {
                 dateParam = formatISO(new Date());
             } else if (selectedPeriod === 'yesterday') {
@@ -187,11 +167,7 @@ function ManagementDashboard() {
                             };
                         }
 
-                        if (
-                            parsedData.enhanced_analytics &&
-                            parsedData.enhanced_analytics.sales &&
-                            parsedData.enhanced_analytics.sales.performance_metrics
-                        ) {
+                        if (parsedData.enhanced_analytics && parsedData.enhanced_analytics.sales && parsedData.enhanced_analytics.sales.performance_metrics) {
                             parsedData.enhanced_analytics.sales.performance_metrics = {
                                 ...parsedData.enhanced_analytics.sales.performance_metrics,
                                 food_cost_percentage: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.food_cost_percentage, 0),
@@ -211,9 +187,6 @@ function ManagementDashboard() {
                         }
 
                         setDashboardData(parsedData);
-                        if (selectedPeriod === 'custom' && effectiveCustomDate) {
-                            setLastLoadedCustomDate(effectiveCustomDate);
-                        }
                         generateAlerts(parsedData);
 
                         setLoading(false);
@@ -789,51 +762,6 @@ function ManagementDashboard() {
 
  
 
-    const isDashboardBusy = () => (
-        loading ||
-        cardLoading.metrics ||
-        cardLoading.shawarma ||
-        cardLoading.sales ||
-        cardLoading.inventory
-    );
-
-    const isValidDateValue = (value) => {
-        if (!value) return false;
-        const parsed = new Date(value);
-        return !isNaN(parsed.getTime());
-    };
-
-    const commitCustomDateSelection = (value, options = {}) => {
-        const resolvedDate = typeof value === 'string' ? value : pendingCustomDate;
-        const allowDuringPicker = options.allowDuringPicker === true;
-        const requireDirty = options.requireDirty === true;
-
-        if (selectedPeriod !== 'custom') return;
-        if (!isValidDateValue(resolvedDate)) return;
-        if (requireDirty && !customDateDirty) return;
-        if (!allowDuringPicker && isCustomPickerOpen) return;
-        if (isDashboardBusy()) return;
-        if (resolvedDate === lastLoadedCustomDate) {
-            setCustomDateDirty(false);
-            return;
-        }
-
-        setCustomDateDirty(false);
-        loadDashboardData(resolvedDate);
-    };
-
-    const handleCustomDateChange = (event) => {
-        const value = event.target.value;
-        setCustomDate(value);
-        setPendingCustomDate(value);
-        setCustomDateDirty(true);
-
-        // Commit immediately when a new date is chosen, even if the native picker
-        // keeps the input focused. This only fires when the value actually changes
-        // (not while navigating the calendar).
-        commitCustomDateSelection(value, { allowDuringPicker: true });
-    };
-
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -848,13 +776,10 @@ function ManagementDashboard() {
                         <select
                             value={selectedPeriod}
                             onChange={e => {
-                                const newPeriod = e.target.value;
-                                setSelectedPeriod(newPeriod);
-                                setCustomDate('');
-                                setLastLoadedCustomDate('');
-                                setPendingCustomDate('');
-                                setIsCustomPickerOpen(false);
-                                setCustomDateDirty(false);
+                                setSelectedPeriod(e.target.value);
+                                if (e.target.value !== 'custom') {
+                                    setCustomDate('');
+                                }
                             }}
                             className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                         >
@@ -870,25 +795,14 @@ function ManagementDashboard() {
                             <input
                                 type="date"
                                 value={customDate}
-                                onChange={handleCustomDateChange}
-                                onFocus={() => setIsCustomPickerOpen(true)}
-                                onBlur={() => {
-                                    setIsCustomPickerOpen(false);
-                                    commitCustomDateSelection(undefined, { requireDirty: true });
-                                }}
+                                onChange={e => setCustomDate(e.target.value)}
                                 className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                             />
                         )}
                         
                         <button
                             onClick={loadDashboardData}
-                            disabled={
-                                cardLoading.metrics ||
-                                cardLoading.shawarma ||
-                                cardLoading.sales ||
-                                cardLoading.inventory ||
-                                (selectedPeriod === 'custom' && !customDate)
-                            }
+                            disabled={cardLoading.metrics || cardLoading.shawarma || cardLoading.sales || cardLoading.inventory}
                             className="bg-olive-600 text-white px-4 py-2 rounded hover:bg-olive-700 disabled:opacity-50 flex items-center gap-2"
                         >
                             {(cardLoading.metrics || cardLoading.shawarma || cardLoading.sales || cardLoading.inventory) && (

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -15,6 +15,8 @@ function ManagementDashboard() {
         inventory: true
     });
     const [lastLoadedCustomDate, setLastLoadedCustomDate] = React.useState('');
+    const [pendingCustomDate, setPendingCustomDate] = React.useState('');
+    const [isCustomPickerOpen, setIsCustomPickerOpen] = React.useState(false);
     const [showDataStatus, setShowDataStatus] = React.useState(false);
     const [showDebugData, setShowDebugData] = React.useState(false);
 
@@ -788,17 +790,27 @@ function ManagementDashboard() {
         cardLoading.inventory
     );
 
+    const commitCustomDateSelection = (value) => {
+        const resolvedDate = typeof value === 'string' ? value : pendingCustomDate;
+
+        if (selectedPeriod !== 'custom') return;
+        if (!resolvedDate) return;
+        if (isCustomPickerOpen) return;
+        if (isDashboardBusy()) return;
+        if (resolvedDate === lastLoadedCustomDate) return;
+
+        loadDashboardData(resolvedDate);
+    };
+
     const handleCustomDateChange = (event) => {
         const value = event.target.value;
         setCustomDate(value);
+        setPendingCustomDate(value);
 
-        if (selectedPeriod !== 'custom') return;
-        if (!value) return;
-        if (isDashboardBusy()) return;
-        if (value === lastLoadedCustomDate) return;
-
-        // Trigger the load immediately when the picker commits a new date
-        loadDashboardData(value);
+        // If the picker is already closed (e.g., keyboard entry), commit immediately
+        if (!isCustomPickerOpen) {
+            commitCustomDateSelection(value);
+        }
     };
 
     return (
@@ -819,6 +831,8 @@ function ManagementDashboard() {
                                 setSelectedPeriod(newPeriod);
                                 setCustomDate('');
                                 setLastLoadedCustomDate('');
+                                setPendingCustomDate('');
+                                setIsCustomPickerOpen(false);
                             }}
                             className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                         >
@@ -835,6 +849,11 @@ function ManagementDashboard() {
                                 type="date"
                                 value={customDate}
                                 onChange={handleCustomDateChange}
+                                onFocus={() => setIsCustomPickerOpen(true)}
+                                onBlur={() => {
+                                    setIsCustomPickerOpen(false);
+                                    commitCustomDateSelection();
+                                }}
                                 className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                             />
                         )}

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -18,9 +18,12 @@ function ManagementDashboard() {
     const [showDebugData, setShowDebugData] = React.useState(false);
 
     React.useEffect(() => {
-        if (selectedPeriod === 'custom' && !customDate) return;
+        // Only auto-load for non-custom periods. Custom dates should be fetched
+        // explicitly (e.g., via the Refresh button) after the user commits a date
+        // selection to avoid triggering requests while navigating the calendar.
+        if (selectedPeriod === 'custom') return;
         loadDashboardData();
-    }, [selectedPeriod, customDate]);
+    }, [selectedPeriod]);
 
     const getAcceptableRemainingRange = (stackWeightKg) => {
         return {

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -170,7 +170,11 @@ function ManagementDashboard() {
                             };
                         }
 
-                        if (parsedData.enhanced_analytics?.sales?.performance_metrics) {
+                        if (
+                            parsedData.enhanced_analytics &&
+                            parsedData.enhanced_analytics.sales &&
+                            parsedData.enhanced_analytics.sales.performance_metrics
+                        ) {
                             parsedData.enhanced_analytics.sales.performance_metrics = {
                                 ...parsedData.enhanced_analytics.sales.performance_metrics,
                                 food_cost_percentage: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.food_cost_percentage, 0),

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -18,9 +18,8 @@ function ManagementDashboard() {
     const [showDebugData, setShowDebugData] = React.useState(false);
 
     React.useEffect(() => {
-        if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
-            loadDashboardData();
-        }
+        if (selectedPeriod === 'custom' && !customDate) return;
+        loadDashboardData();
     }, [selectedPeriod, customDate]);
 
     const getAcceptableRemainingRange = (stackWeightKg) => {
@@ -116,6 +115,10 @@ function ManagementDashboard() {
     };
 
     const loadDashboardData = async () => {
+        if (selectedPeriod === 'custom' && !customDate) {
+            return;
+        }
+
         if (dashboardData) {
             setCardLoading({
                 metrics: true,
@@ -150,6 +153,33 @@ function ManagementDashboard() {
                     console.log("Received dashboard data:", data);
                     try {
                         const parsedData = JSON.parse(data);
+
+                        const safeNumber = (value, defaultValue = 0) => {
+                            const num = Number(value);
+                            return Number.isFinite(num) ? num : defaultValue;
+                        };
+
+                        if (parsedData.sales) {
+                            parsedData.sales = {
+                                ...parsedData.sales,
+                                total_revenue: safeNumber(parsedData.sales.total_revenue, 0),
+                                shawarma_revenue: safeNumber(parsedData.sales.shawarma_revenue, 0),
+                                other_food_revenue: safeNumber(parsedData.sales.other_food_revenue, 0),
+                                petty_cash_total: safeNumber(parsedData.sales.petty_cash_total, 0),
+                                food_cost_percentage: safeNumber(parsedData.sales.food_cost_percentage, 0)
+                            };
+                        }
+
+                        if (parsedData.enhanced_analytics?.sales?.performance_metrics) {
+                            parsedData.enhanced_analytics.sales.performance_metrics = {
+                                ...parsedData.enhanced_analytics.sales.performance_metrics,
+                                food_cost_percentage: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.food_cost_percentage, 0),
+                                revenue_quality_score: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.revenue_quality_score, 0),
+                                petty_cash_percentage: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.petty_cash_percentage, 0),
+                                payment_method_diversity: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.payment_method_diversity, 0),
+                                shawarma_percentage: safeNumber(parsedData.enhanced_analytics.sales.performance_metrics.shawarma_percentage, 0)
+                            };
+                        }
 
                         if (parsedData.shawarma) {
                             parsedData.shawarma = computeShawarmaMetrics(parsedData.shawarma);
@@ -749,10 +779,9 @@ function ManagementDashboard() {
                         <select
                             value={selectedPeriod}
                             onChange={e => {
-                                setSelectedPeriod(e.target.value);
-                                if (e.target.value !== 'custom') {
-                                    setCustomDate('');
-                                }
+                                const newPeriod = e.target.value;
+                                setSelectedPeriod(newPeriod);
+                                setCustomDate('');
                             }}
                             className="px-3 py-2 border rounded focus:ring-2 focus:ring-olive-500"
                         >
@@ -775,7 +804,13 @@ function ManagementDashboard() {
                         
                         <button
                             onClick={loadDashboardData}
-                            disabled={cardLoading.metrics || cardLoading.shawarma || cardLoading.sales || cardLoading.inventory}
+                            disabled={
+                                cardLoading.metrics ||
+                                cardLoading.shawarma ||
+                                cardLoading.sales ||
+                                cardLoading.inventory ||
+                                (selectedPeriod === 'custom' && !customDate)
+                            }
                             className="bg-olive-600 text-white px-4 py-2 rounded hover:bg-olive-700 disabled:opacity-50 flex items-center gap-2"
                         >
                             {(cardLoading.metrics || cardLoading.shawarma || cardLoading.sales || cardLoading.inventory) && (


### PR DESCRIPTION
## Summary
- delay dashboard fetches until a custom date is explicitly selected and clear stale selections when changing periods
- block manual refresh for missing custom dates and avoid triggering loads without a date
- normalize sales metric numbers when parsing dashboard responses to prevent runtime errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693535c408c48325906c85b4e0fb6ef7)