### PR TITLE
Add delivery aggregator settings management

### DIFF
--- a/BilingualEmployeeDailyEntryTab.html
+++ b/BilingualEmployeeDailyEntryTab.html
@@ -419,6 +419,46 @@ function BilingualEmployeeDailyEntryTab(props) {
         }));
     };
 
+    const buildEmptyPaymentBreakdown = React.useCallback(() => ({
+        cash_sales: '',
+        card_sales: '',
+        delivery_aggregators: (aggregatorOptions || []).map(item => ({ ...item, amount: '' })),
+        aggregator_details: ''
+    }), [aggregatorOptions]);
+
+    const clearEntryValues = React.useCallback(() => {
+        setFormData(prev => ({
+            ...prev,
+            shawarmaStack: { starting_weight: '', remaining_weight: '', shaving_weight: '', staff_meals_weight: '', orders_weight: '' },
+            rawProteins: {
+                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
+                chicken_shawarma_opening: '', chicken_shawarma_received: '', chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
+                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
+            },
+            marinatedProteins: {
+                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
+                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
+                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
+                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
+                marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
+            },
+            bread: {
+                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
+                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
+                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
+            },
+            highCostItems: {
+                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
+                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
+            },
+            sales: {
+                total_revenue: '', shawarma_revenue: '', other_food_revenue: '', petty_cash_total: ''
+            }
+        }));
+        setPaymentBreakdown(buildEmptyPaymentBreakdown());
+        setPettyCashEntries([]);
+    }, [buildEmptyPaymentBreakdown]);
+
     const INVENTORY_CONFIG = {
         rawProteins: {
             titleKey: 'frozenRawProteins',
@@ -470,10 +510,20 @@ function BilingualEmployeeDailyEntryTab(props) {
         const applyAggregators = (list) => {
             const active = (list || []).filter(item => item.active !== false);
             setAggregatorOptions(active);
-            setPaymentBreakdown(prev => ({
-                ...prev,
-                delivery_aggregators: active.map(item => ({ ...item, amount: '' }))
-            }));
+            setPaymentBreakdown(prev => {
+                const existing = prev.delivery_aggregators || [];
+                const mapped = active.map(option => {
+                    const matched = existing.find(item => item.id === option.id || item.name === option.name);
+                    return { ...option, amount: matched ? matched.amount || '' : '' };
+                });
+                const hasExistingAmounts = mapped.some(item => item.amount && String(item.amount).trim() !== '');
+
+                return {
+                    ...prev,
+                    delivery_aggregators: mapped.length ? mapped : active.map(item => ({ ...item, amount: '' })),
+                    aggregator_details: hasExistingAmounts ? (prev.aggregator_details || '') : ''
+                };
+            });
         };
 
         google.script.run
@@ -546,11 +596,12 @@ function BilingualEmployeeDailyEntryTab(props) {
                 .withSuccessHandler(result => {
                     const data = JSON.parse(result);
                     setCheckingExistingData(false);
-                    
+
                     if (data.exists) {
                         setDuplicateWarning(true);
                         setFieldsLocked(true);
                         setShowLoadExistingPin(true);
+                        clearEntryValues();
                     } else {
                         resetFormToClean();
                     }
@@ -668,15 +719,32 @@ function BilingualEmployeeDailyEntryTab(props) {
                                         cash_sales: data.salesBreakdown ? String(data.salesBreakdown.cash_sales || '') : (data.sales ? String(data.sales.cash_sales || '') : ''),
                                         card_sales: data.salesBreakdown ? String(data.salesBreakdown.card_sales || '') : (data.sales ? String(data.sales.card_sales || '') : ''),
                                         delivery_aggregators: (() => {
-                                            try {
-                                                const parsed = data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
-                                                return aggregatorOptions.map(option => {
-                                                    const matched = parsed.find(p => p.id === option.id || p.name === option.name);
-                                                    return { ...option, amount: matched ? String(matched.amount || '') : '' };
-                                                });
-                                            } catch (error) {
-                                                return aggregatorOptions.map(option => ({ ...option, amount: '' }));
+                                            const parsed = (() => {
+                                                try {
+                                                    return data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
+                                                } catch (error) {
+                                                    return [];
+                                                }
+                                            })();
+
+                                            const sourceAggregators = (aggregatorOptions && aggregatorOptions.length) ? aggregatorOptions : parsed;
+                                            let resolved = sourceAggregators.map(option => {
+                                                const matched = parsed.find(p => p.id === option.id || p.name === option.name);
+                                                return { ...option, amount: matched ? String(matched.amount || '') : '' };
+                                            });
+
+                                            if (!resolved.length && parsed.length) {
+                                                resolved = parsed.map(item => ({ ...item, amount: String(item.amount || '') }));
                                             }
+
+                                            if (!resolved.length && data.sales && (data.sales.delivery_aggregator_1 || data.sales.delivery_sales)) {
+                                                const fallbackTotal = String(data.sales.delivery_aggregator_1 || data.sales.delivery_sales || '');
+                                                const baseOption = sourceAggregators[0] || { id: 'delivery_fallback', name: 'Delivery Aggregators' };
+                                                return [{ ...baseOption, amount: fallbackTotal }];
+                                            }
+
+                                            const emptyAggregators = buildEmptyPaymentBreakdown().delivery_aggregators;
+                                            return resolved.length ? resolved : emptyAggregators;
                                         })(),
                                         aggregator_details: data.salesBreakdown ? String(data.salesBreakdown.aggregator_details || '') : ''
                                     },
@@ -770,60 +838,21 @@ function BilingualEmployeeDailyEntryTab(props) {
         }
     };
 
+
     const resetFormToClean = () => {
-        setFormData({
-            shawarmaStack: {
-                starting_weight: '', remaining_weight: '', shaving_weight: '',
-                staff_meals_weight: '', orders_weight: ''
-            },
-            rawProteins: {
-                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', 
-                frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
-                chicken_shawarma_opening: '', chicken_shawarma_received: '', 
-                chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
-                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
-            },
-            marinatedProteins: {
-                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
-                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
-                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
-                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
-    // ADD THESE LINES:
-    marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
-},
-            bread: {
-                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
-                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
-                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
-            },
-            highCostItems: {
-                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
-                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
-            },
-            sales: {
-                total_revenue: '',
-                shawarma_revenue: '',
-                other_food_revenue: '',
-                petty_cash_total: ''
-            },
-            paymentBreakdown: {
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregators: aggregatorOptions.map(a => ({ ...a, amount: '' })),
-                aggregator_details: ''
-            },
-            notes: ''
-        });
-        
+        clearEntryValues();
+
         setDuplicateWarning(false);
         setIsUpdateMode(false);
         setFieldsLocked(false);
+        setShowPinInput(false);
+        setManagementPin('');
         setShowLoadExistingPin(false);
         setLoadExistingPin('');
-        setLoadingExistingData(false);
         setPinError(false);
-        setPettyCashEntries([]);
+        setPinAttempted(false);
     };
+
     
     const handleInputChange = (section, field, value) => {
         const normalized = normalizeNumberInput(value);
@@ -908,49 +937,12 @@ function BilingualEmployeeDailyEntryTab(props) {
         }
     };
     
+
     const resetForm = () => {
-        setFormData({
-            shawarmaStack: {
-                starting_weight: '', remaining_weight: '', shaving_weight: '',
-                staff_meals_weight: '', orders_weight: ''
-            },
-            rawProteins: {
-                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
-                chicken_shawarma_opening: '', chicken_shawarma_received: '', chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
-                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
-            },
-            marinatedProteins: {
-                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
-                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
-                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
-                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
-    // ADD THESE LINES:
-    marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
-            },
-            bread: {
-                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
-                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
-                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
-            },
-            highCostItems: {
-                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
-                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
-            },
-            sales: {
-                total_revenue: '',
-                shawarma_revenue: '',
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregator_1: '',
-                delivery_aggregator_2: '',
-                other_food_revenue: '',
-                petty_cash_total: ''
-            },
-            notes: ''
-        });
-        setPettyCashEntries([]);
+        clearEntryValues();
         setIsUpdateMode(false);
     };
+
     
     const cancelUpdate = () => {
         setShowPinInput(false);
@@ -1482,10 +1474,7 @@ function BilingualEmployeeDailyEntryTab(props) {
                             React.createElement('div', { className: 'space-y-2' },
                                 (paymentBreakdown.delivery_aggregators || []).map(item => (
                                     React.createElement('div', { key: item.id, className: 'border rounded p-3 bg-white shadow-sm flex items-center justify-between' },
-                                        React.createElement('div', null,
-                                            React.createElement('p', { className: 'text-sm font-medium text-gray-800' }, item.name || 'Aggregator'),
-                                            React.createElement('p', { className: 'text-xs text-gray-500' }, `${t('commission')}: ${item.commission_percent || 0}%`)
-                                        ),
+                                        React.createElement('p', { className: 'text-sm font-medium text-gray-800 mb-1 md:mb-0' }, item.name || 'Aggregator'),
                                         React.createElement('div', { className: 'w-32' },
                                             React.createElement('input', {
                                                 type: 'number',

--- a/BilingualEmployeeDailyEntryTab.html
+++ b/BilingualEmployeeDailyEntryTab.html
@@ -361,12 +361,14 @@ function BilingualEmployeeDailyEntryTab(props) {
         sales: {
             total_revenue: '',
             shawarma_revenue: '',
-            cash_sales: '',
-            card_sales: '',
-            delivery_aggregator_1: '',
-            delivery_aggregator_2: '',
             other_food_revenue: '',
             petty_cash_total: ''
+        },
+        paymentBreakdown: {
+            cash_sales: '',
+            card_sales: '',
+            delivery_aggregators: [],
+            aggregator_details: ''
         },
         notes: ''
     });
@@ -395,10 +397,26 @@ function BilingualEmployeeDailyEntryTab(props) {
     });
     const [editingEntryIndex, setEditingEntryIndex] = React.useState(-1);
     const [aggregatorOptions, setAggregatorOptions] = React.useState([]);
+    const [paymentBreakdown, setPaymentBreakdown] = React.useState({
+        cash_sales: '',
+        card_sales: '',
+        delivery_aggregators: [],
+        aggregator_details: ''
+    });
 
     const getAggregatorLabel = (index) => {
         const fallbackKey = index === 0 ? 'deliveryAggregator1' : 'deliveryAggregator2';
         return (aggregatorOptions[index] && aggregatorOptions[index].name) ? aggregatorOptions[index].name : t(fallbackKey);
+    };
+
+    const updateAggregatorAmount = (id, value) => {
+        const normalized = normalizeNumberInput(value);
+        setPaymentBreakdown(prev => ({
+            ...prev,
+            delivery_aggregators: (prev.delivery_aggregators || []).map(item =>
+                item.id === id ? { ...item, amount: normalized } : item
+            )
+        }));
     };
 
     const INVENTORY_CONFIG = {
@@ -452,6 +470,10 @@ function BilingualEmployeeDailyEntryTab(props) {
         const applyAggregators = (list) => {
             const active = (list || []).filter(item => item.active !== false);
             setAggregatorOptions(active);
+            setPaymentBreakdown(prev => ({
+                ...prev,
+                delivery_aggregators: active.map(item => ({ ...item, amount: '' }))
+            }));
         };
 
         google.script.run
@@ -639,12 +661,24 @@ function BilingualEmployeeDailyEntryTab(props) {
                                     sales: {
                                         total_revenue: data.sales ? String(data.sales.total_revenue || '') : '',
                                         shawarma_revenue: data.sales ? String(data.sales.shawarma_revenue || '') : '',
-                                        cash_sales: data.sales ? String(data.sales.cash_sales || '') : '',
-                                        card_sales: data.sales ? String(data.sales.card_sales || '') : '',
-                                        delivery_aggregator_1: data.sales ? String(data.sales.delivery_aggregator_1 || '') : '',
-                                        delivery_aggregator_2: data.sales ? String(data.sales.delivery_aggregator_2 || '') : '',
                                         other_food_revenue: data.sales ? String(data.sales.other_food_revenue || '') : '',
                                         petty_cash_total: data.sales ? String(data.sales.petty_cash_total || '') : ''
+                                    },
+                                    paymentBreakdown: {
+                                        cash_sales: data.salesBreakdown ? String(data.salesBreakdown.cash_sales || '') : (data.sales ? String(data.sales.cash_sales || '') : ''),
+                                        card_sales: data.salesBreakdown ? String(data.salesBreakdown.card_sales || '') : (data.sales ? String(data.sales.card_sales || '') : ''),
+                                        delivery_aggregators: (() => {
+                                            try {
+                                                const parsed = data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
+                                                return aggregatorOptions.map(option => {
+                                                    const matched = parsed.find(p => p.id === option.id || p.name === option.name);
+                                                    return { ...option, amount: matched ? String(matched.amount || '') : '' };
+                                                });
+                                            } catch (error) {
+                                                return aggregatorOptions.map(option => ({ ...option, amount: '' }));
+                                            }
+                                        })(),
+                                        aggregator_details: data.salesBreakdown ? String(data.salesBreakdown.aggregator_details || '') : ''
                                     },
                                     rawProteins: {
                                         frozen_chicken_breast_opening: data.rawProteins ? String(data.rawProteins.frozen_chicken_breast_opening || '') : '',
@@ -769,12 +803,14 @@ function BilingualEmployeeDailyEntryTab(props) {
             sales: {
                 total_revenue: '',
                 shawarma_revenue: '',
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregator_1: '',
-                delivery_aggregator_2: '',
                 other_food_revenue: '',
                 petty_cash_total: ''
+            },
+            paymentBreakdown: {
+                cash_sales: '',
+                card_sales: '',
+                delivery_aggregators: aggregatorOptions.map(a => ({ ...a, amount: '' })),
+                aggregator_details: ''
             },
             notes: ''
         });
@@ -825,8 +861,16 @@ function BilingualEmployeeDailyEntryTab(props) {
                 shawarmaStack: formData.shawarmaStack,
                 sales: {
                     ...formData.sales,
+                    cash_sales: paymentBreakdown.cash_sales,
+                    card_sales: paymentBreakdown.card_sales,
+                    delivery_aggregator_1: calculateDeliveryTotal(),
+                    delivery_aggregator_2: 0,
                     other_food_revenue: calculateOtherFoodRevenue(),
                     petty_cash_total: calculatePettyCashTotal()
+                },
+                paymentBreakdown: {
+                    ...paymentBreakdown,
+                    delivery_aggregators: paymentBreakdown.delivery_aggregators || []
                 },
                 rawProteins: formData.rawProteins,
                 marinatedProteins: formData.marinatedProteins,
@@ -922,6 +966,10 @@ function BilingualEmployeeDailyEntryTab(props) {
 
     const calculatePettyCashTotal = () => {
         return pettyCashEntries.reduce((sum, e) => sum + (parseFloat(e.amount) || 0), 0);
+    };
+
+    const calculateDeliveryTotal = () => {
+        return (paymentBreakdown.delivery_aggregators || []).reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
     };
 
     const handleAddPettyCashEntry = () => {
@@ -1416,47 +1464,49 @@ function BilingualEmployeeDailyEntryTab(props) {
                                 disabled: fieldsLocked
                             })
                         ),
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('cashSales')),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.cash_sales,
-                                onChange: e => handleInputChange('sales', 'cash_sales', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
+                        ['cash_sales', 'card_sales'].map(key => (
+                            React.createElement('div', { key },
+                                React.createElement('label', { className: 'block text-sm font-medium mb-1' }, key === 'cash_sales' ? t('cashSales') : t('cardSales')),
+                                React.createElement('input', {
+                                    type: 'number',
+                                    step: '0.01',
+                                    value: paymentBreakdown[key],
+                                    onChange: e => setPaymentBreakdown(prev => ({ ...prev, [key]: normalizeNumberInput(e.target.value) })),
+                                    className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                    disabled: fieldsLocked
+                                })
+                            )
+                        )),
+                        React.createElement('div', { className: 'md:col-span-2' },
+                            React.createElement('label', { className: 'block text-sm font-medium mb-2' }, t('deliveryAggregator1')),
+                            React.createElement('div', { className: 'space-y-2' },
+                                (paymentBreakdown.delivery_aggregators || []).map(item => (
+                                    React.createElement('div', { key: item.id, className: 'border rounded p-3 bg-white shadow-sm flex items-center justify-between' },
+                                        React.createElement('div', null,
+                                            React.createElement('p', { className: 'text-sm font-medium text-gray-800' }, item.name || 'Aggregator'),
+                                            React.createElement('p', { className: 'text-xs text-gray-500' }, `${t('commission')}: ${item.commission_percent || 0}%`)
+                                        ),
+                                        React.createElement('div', { className: 'w-32' },
+                                            React.createElement('input', {
+                                                type: 'number',
+                                                step: '0.01',
+                                                value: item.amount,
+                                                onChange: e => updateAggregatorAmount(item.id, e.target.value),
+                                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                                disabled: fieldsLocked
+                                            })
+                                        )
+                                    )
+                                ))
+                            )
                         ),
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('cardSales')),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.card_sales,
-                                onChange: e => handleInputChange('sales', 'card_sales', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
-                        ),
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(0)),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.delivery_aggregator_1,
-                                onChange: e => handleInputChange('sales', 'delivery_aggregator_1', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
-                        ),
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(1)),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.delivery_aggregator_2,
-                                onChange: e => handleInputChange('sales', 'delivery_aggregator_2', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                        React.createElement('div', { className: 'md:col-span-2' },
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('notes')),
+                            React.createElement('textarea', {
+                                value: paymentBreakdown.aggregator_details,
+                                onChange: e => setPaymentBreakdown(prev => ({ ...prev, aggregator_details: e.target.value })),
+                                className: 'w-full p-3 border rounded focus:ring-2 focus:ring-redbrand-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                rows: '2',
                                 disabled: fieldsLocked
                             })
                         ),

--- a/BilingualEmployeeDailyEntryTab.html
+++ b/BilingualEmployeeDailyEntryTab.html
@@ -394,6 +394,12 @@ function BilingualEmployeeDailyEntryTab(props) {
         paid_by: ''
     });
     const [editingEntryIndex, setEditingEntryIndex] = React.useState(-1);
+    const [aggregatorOptions, setAggregatorOptions] = React.useState([]);
+
+    const getAggregatorLabel = (index) => {
+        const fallbackKey = index === 0 ? 'deliveryAggregator1' : 'deliveryAggregator2';
+        return (aggregatorOptions[index] && aggregatorOptions[index].name) ? aggregatorOptions[index].name : t(fallbackKey);
+    };
 
     const INVENTORY_CONFIG = {
         rawProteins: {
@@ -441,6 +447,33 @@ function BilingualEmployeeDailyEntryTab(props) {
         { key: 'transportation', labelKey: 'categoryTransportation' },
         { key: 'other', labelKey: 'categoryOther' }
     ];
+
+    React.useEffect(() => {
+        const applyAggregators = (list) => {
+            const active = (list || []).filter(item => item.active !== false);
+            setAggregatorOptions(active);
+        };
+
+        google.script.run
+            .withSuccessHandler(result => {
+                try {
+                    const parsed = Array.isArray(result)
+                        ? result
+                        : (typeof result === 'string' && result.trim())
+                            ? JSON.parse(result)
+                            : [];
+                    applyAggregators(parsed);
+                } catch (error) {
+                    console.error('Failed to parse aggregator settings', error);
+                    applyAggregators([]);
+                }
+            })
+            .withFailureHandler(err => {
+                console.error('Failed to load aggregators', err);
+                applyAggregators([]);
+            })
+            .getAggregatorSettings(false);
+    }, []);
 
     React.useEffect(() => {
         if (selectedDate) {
@@ -1406,7 +1439,7 @@ function BilingualEmployeeDailyEntryTab(props) {
                             })
                         ),
                         React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('deliveryAggregator1')),
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(0)),
                             React.createElement('input', {
                                 type: 'number',
                                 step: '0.01',
@@ -1417,7 +1450,7 @@ function BilingualEmployeeDailyEntryTab(props) {
                             })
                         ),
                         React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('deliveryAggregator2')),
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(1)),
                             React.createElement('input', {
                                 type: 'number',
                                 step: '0.01',

--- a/Code.gs
+++ b/Code.gs
@@ -2,6 +2,15 @@
 // FULLY COMPATIBLE with existing Employee app data structure
 // Based on Employee Code.gs with Management features added
 
+// Optional namespace for safe testing without touching production sheets
+const DATA_NAMESPACE = (PropertiesService.getScriptProperties().getProperty('DATA_NAMESPACE') || '').trim();
+
+function getSheetWithNamespace(sheetName, ss) {
+  const spreadsheet = ss || SpreadsheetApp.getActiveSpreadsheet();
+  const resolvedName = DATA_NAMESPACE ? `${DATA_NAMESPACE}${sheetName}` : sheetName;
+  return spreadsheet.getSheetByName(resolvedName);
+}
+
 // Database structure definition (EXACT from Employee Code.gs)
 const REQUIRED_SHEETS = {
   // Enhanced Employee Management with language support (UNCHANGED)
@@ -106,6 +115,32 @@ const REQUIRED_SHEETS = {
     ]
   },
 
+  DailySales: {
+    requiredHeaders: [
+      'id', 'sales_date', 'total_revenue', 'shawarma_revenue', 'total_food_cost',
+      'food_cost_percentage', 'total_orders', 'employee_id', 'created_at', 'updated_at'
+    ]
+  },
+
+  DailySalesBreakdown: {
+    requiredHeaders: [
+      'id', 'sales_date', 'daily_sales_id', 'cash_sales', 'card_sales', 'delivery_sales',
+      'aggregator_details', 'cash_expenses', 'expense_notes', 'created_at', 'updated_at'
+    ]
+  },
+
+  DeliveryAggregators: {
+    requiredHeaders: [
+      'id', 'name', 'commission_percent', 'active', 'created_at', 'updated_at'
+    ]
+  },
+
+  DailyPettyCash: {
+    requiredHeaders: [
+      'id', 'sales_date', 'daily_sales_id', 'category', 'description', 'amount', 'paid_by', 'created_at', 'updated_at'
+    ]
+  },
+
   Item: {
     requiredHeaders: [
       'id', 'name', 'category', 'unit', 'frequency', 'is_prepared', 'cost_per_unit',
@@ -124,15 +159,6 @@ const REQUIRED_SHEETS = {
   PettyCashDetail: {
     requiredHeaders: [
       'id', 'daily_sales_id', 'category', 'description', 'amount', 'paid_by',
-      'employee_id', 'created_at', 'updated_at'
-    ]
-  },
-
-  DailySales: {
-    requiredHeaders: [
-      'id', 'sales_date', 'total_revenue', 'shawarma_revenue', 'other_food_revenue',
-      'cash_sales', 'card_sales', 'delivery_aggregator_1', 'delivery_aggregator_2',
-      'total_food_cost', 'food_cost_percentage', 'total_orders', 'petty_cash_total',
       'employee_id', 'created_at', 'updated_at'
     ]
   },
@@ -1881,7 +1907,7 @@ function assessDataQuality(baseReport) {
 // Helper function to get sheet data (EXACT from Employee Code.gs)
 function getSheetData(sheetName) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const sheet = ss.getSheetByName(sheetName);
+  const sheet = getSheetWithNamespace(sheetName, ss);
   
   if (!sheet || sheet.getLastRow() <= 1) {
     return [];
@@ -2333,6 +2359,61 @@ function generateWeeklyReport(date) {
   } catch (error) {
     Logger.log('Error generating weekly report: ' + error.toString());
     throw new Error('Failed to generate weekly report: ' + error.message);
+  }
+}
+
+// Delivery aggregator management
+function getAggregatorSettings(returnRaw) {
+  const sheet = getSheetWithNamespace('DeliveryAggregators');
+  if (!sheet || sheet.getLastRow() <= 1) {
+    return returnRaw ? [] : JSON.stringify([]);
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+
+  const items = data.slice(1).map(row => {
+    const record = {};
+    headers.forEach((header, idx) => record[header] = row[idx]);
+    return record;
+  });
+
+  return returnRaw ? items : JSON.stringify(items);
+}
+
+function saveAggregatorSettings(settingsJson) {
+  try {
+    const settings = JSON.parse(settingsJson);
+    const sheet = getSheetWithNamespace('DeliveryAggregators');
+    if (!sheet) {
+      return JSON.stringify({ success: false, message: 'Aggregator sheet missing' });
+    }
+
+    const headers = REQUIRED_SHEETS.DeliveryAggregators.requiredHeaders;
+    sheet.clearContents();
+    sheet.getRange(1, 1, 1, headers.length)
+      .setValues([headers])
+      .setBackground('#E6E6E6')
+      .setFontWeight('bold');
+
+    settings.forEach(item => {
+      const id = item.id || Utilities.getUuid();
+      const created = item.created_at ? new Date(item.created_at) : new Date();
+      const row = [
+        id,
+        item.name || '',
+        parseFloat(item.commission_percent) || 0,
+        item.active === false ? false : true,
+        created,
+        new Date()
+      ];
+      sheet.appendRow(row);
+    });
+
+    return JSON.stringify({ success: true });
+  } catch (error) {
+    Logger.log('Error saving aggregator settings: ' + error.toString());
+    return JSON.stringify({ success: false, message: 'Failed to save aggregators' });
   }
 }
 

--- a/Code.gs
+++ b/Code.gs
@@ -790,7 +790,7 @@ function deleteExistingEntries(dateString) {
       'SnapshotLog'
     ];
 
-    const sheetModes = MIGRATION_CONFIG.dualWriteMode ? ['namespaced', 'base'] : ['namespaced'];
+    const sheetModes = (MIGRATION_CONFIG.dualWriteMode && DATA_NAMESPACE) ? ['namespaced', 'base'] : ['namespaced'];
 
     const getSheetByMode = (sheetName, mode) => {
       return mode === 'base' ? ss.getSheetByName(sheetName) : getSheetWithNamespace(sheetName, ss);
@@ -889,6 +889,9 @@ function saveDailyEntry(entryData) {
 
     const entryDate = entryData.date ? new Date(entryData.date).toDateString() : new Date().toDateString();
 
+    const hasNamespace = !!DATA_NAMESPACE;
+    const legacySaveEnabled = MIGRATION_CONFIG.dualWriteMode && hasNamespace;
+
     if (entryData.isUpdate) {
       if (!entryData.managementPin || !validateManagementPin(entryData.managementPin)) {
         return JSON.stringify({
@@ -919,7 +922,7 @@ function saveDailyEntry(entryData) {
       }
     }
 
-    if (MIGRATION_CONFIG.dualWriteMode) {
+    if (legacySaveEnabled) {
       try {
         const oldSaveResult = saveDailyEntryToOldTables(entryData);
         logMigrationActivity('old_tables_save', {
@@ -1424,19 +1427,28 @@ function mapSnapshotLogToFormFormat(snapshotEntries) {
 }
 
 function generateReportFromOldTables(targetDateString) {
-  const shawarmaData = getSheetData('DailyShawarmaStack');
-  const salesData = getSheetData('DailySales');
-  const rawProteinsData = getSheetData('DailyRawProteins');
-  const marinatedProteinsData = getSheetData('DailyMarinatedProteins');
-  const breadData = getSheetData('DailyBreadTracking');
-  const highCostData = getSheetData('DailyHighCostItems');
+  const dataMode = (MIGRATION_CONFIG.dualWriteMode && DATA_NAMESPACE) ? 'base' : 'namespaced';
+  const shawarmaData = getSheetDataByMode('DailyShawarmaStack', dataMode);
+  const salesData = getSheetDataByMode('DailySales', dataMode);
+  const salesBreakdownData = getSheetDataByMode('DailySalesBreakdown', dataMode);
+  const rawProteinsData = getSheetDataByMode('DailyRawProteins', dataMode);
+  const marinatedProteinsData = getSheetDataByMode('DailyMarinatedProteins', dataMode);
+  const breadData = getSheetDataByMode('DailyBreadTracking', dataMode);
+  const highCostData = getSheetDataByMode('DailyHighCostItems', dataMode);
 
   const todayShawarma = shawarmaData.find(row => row.date && new Date(row.date).toDateString() === targetDateString);
   const todaySales = salesData.find(row => row.sales_date && new Date(row.sales_date).toDateString() === targetDateString);
 
   let pettyCashEntries = [];
+  let todayBreakdown = null;
   if (todaySales) {
-    pettyCashEntries = getPettyCashDetails(todaySales.id);
+    todayBreakdown = salesBreakdownData.find(row => {
+      const matchesDate = row.sales_date && new Date(row.sales_date).toDateString() === targetDateString;
+      const matchesId = row.daily_sales_id && row.daily_sales_id === todaySales.id;
+      return matchesDate || matchesId;
+    }) || null;
+
+    pettyCashEntries = getPettyCashDetails(todaySales.id, { mode: dataMode });
     todaySales.other_food_revenue = (parseFloat(todaySales.total_revenue) || 0) - (parseFloat(todaySales.shawarma_revenue) || 0);
     todaySales.petty_cash_total = calculatePettyCashTotal(pettyCashEntries);
   }
@@ -1448,7 +1460,7 @@ function generateReportFromOldTables(targetDateString) {
 
   return {
     date: targetDateString,
-    dataFound: !!(todayShawarma || todaySales || rawProteins || marinatedProteins || bread || highCostItems),
+    dataFound: !!(todayShawarma || todaySales || rawProteins || marinatedProteins || bread || highCostItems || todayBreakdown),
     shawarma: todayShawarma || null,
     sales: todaySales || null,
     rawProteins: rawProteins,
@@ -1456,6 +1468,7 @@ function generateReportFromOldTables(targetDateString) {
     bread: bread,
     highCostItems: highCostItems,
     pettyCashEntries: pettyCashEntries,
+    salesBreakdown: todayBreakdown,
     notes: ''
   };
 }
@@ -1965,6 +1978,26 @@ function getSheetData(sheetName) {
   });
 }
 
+function getSheetDataByMode(sheetName, mode) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = mode === 'base' ? ss.getSheetByName(sheetName) : getSheetWithNamespace(sheetName, ss);
+
+  if (!sheet || sheet.getLastRow() <= 1) {
+    return [];
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const headers = data[0];
+
+  return data.slice(1).map(row => {
+    const item = {};
+    headers.forEach((header, index) => {
+      item[header] = row[index];
+    });
+    return item;
+  });
+}
+
 // Save Raw Proteins Data (EXACT from Employee Code.gs)
 function saveRawProteinsData(entryData, entryDate, employeeId) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
@@ -2196,13 +2229,14 @@ function savePettyCashDetails(entries, dailySalesId, employeeId) {
   return total;
 }
 
-function getPettyCashDetails(dailySalesId) {
+function getPettyCashDetails(dailySalesId, options = {}) {
   try {
     const entries = [];
     if (!dailySalesId) {
       return entries;
     }
-    const data = Array.isArray(getSheetData('PettyCashDetail')) ? getSheetData('PettyCashDetail') : [];
+    const mode = options.mode || ((MIGRATION_CONFIG.dualWriteMode && DATA_NAMESPACE) ? 'base' : 'namespaced');
+    const data = Array.isArray(getSheetDataByMode('PettyCashDetail', mode)) ? getSheetDataByMode('PettyCashDetail', mode) : [];
     for (let i = 0; i < data.length; i++) {
       const row = data[i];
       if (row && row.daily_sales_id === dailySalesId) {

--- a/Code.gs
+++ b/Code.gs
@@ -779,7 +779,7 @@ function deleteExistingEntries(dateString) {
   try {
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const targetDate = new Date(dateString).toDateString();
-    
+
     const sheetsToClean = [
       'DailyShawarmaStack',
       'DailyRawProteins',
@@ -793,17 +793,17 @@ function deleteExistingEntries(dateString) {
     const deletedDailySalesIds = [];
 
     sheetsToClean.forEach(sheetName => {
-      const sheet = ss.getSheetByName(sheetName);
+      const sheet = getSheetWithNamespace(sheetName, ss);
       if (!sheet) return;
-      
+
       const data = sheet.getDataRange().getValues();
       const headers = data[0];
       const dateFieldName = sheetName === 'DailyShawarmaStack' || sheetName === 'SnapshotLog' ? 'date' :
                            sheetName === 'DailySales' ? 'sales_date' : 'count_date';
       const dateIndex = headers.indexOf(dateFieldName);
-      
+
       if (dateIndex === -1) return;
-      
+
       const rowsToDelete = [];
       for (let i = data.length - 1; i >= 1; i--) {
         if (data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate) {
@@ -822,9 +822,33 @@ function deleteExistingEntries(dateString) {
       });
     });
 
+    const cleanupRelatedSheet = (sheetName, dateField, idField) => {
+      const sheet = getSheetWithNamespace(sheetName, ss);
+      if (!sheet || sheet.getLastRow() <= 1) return;
+
+      const data = sheet.getDataRange().getValues();
+      const headers = data[0];
+      const dateIndex = headers.indexOf(dateField);
+      const idIndex = headers.indexOf(idField);
+      const rowsToDelete = [];
+
+      for (let i = data.length - 1; i >= 1; i--) {
+        const matchesDate = dateIndex !== -1 && data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate;
+        const matchesId = idIndex !== -1 && deletedDailySalesIds.indexOf(data[i][idIndex]) !== -1;
+        if (matchesDate || matchesId) {
+          rowsToDelete.push(i + 1);
+        }
+      }
+
+      rowsToDelete.forEach(rowIndex => sheet.deleteRow(rowIndex));
+    };
+
+    cleanupRelatedSheet('DailySalesBreakdown', 'sales_date', 'daily_sales_id');
+    cleanupRelatedSheet('DailyPettyCash', 'sales_date', 'daily_sales_id');
+
     if (deletedDailySalesIds.length > 0) {
-      const pettySheet = ss.getSheetByName('PettyCashDetail');
-      if (pettySheet) {
+      const pettySheet = getSheetWithNamespace('PettyCashDetail', ss);
+      if (pettySheet && pettySheet.getLastRow() > 1) {
         const pettyData = pettySheet.getDataRange().getValues();
         const pettyHeaders = pettyData[0];
         const dailyIdIndex = pettyHeaders.indexOf('daily_sales_id');
@@ -839,7 +863,7 @@ function deleteExistingEntries(dateString) {
         });
       }
     }
-    
+
   } catch (error) {
     Logger.log('Error deleting existing entries: ' + error.toString());
     throw new Error('Failed to delete existing entries: ' + error.message);
@@ -2042,58 +2066,50 @@ function saveHighCostItemsData(entryData, entryDate, employeeId) {
   highCostSheet.appendRow(row);
 }
 
-// Save Sales Data (EXACT from Employee Code.gs)
+// Save Sales Data with payment breakdown linkage
 function saveSalesData(entryData, entryDate, employeeId) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const salesSheet = ss.getSheetByName('DailySales');
+  const salesSheet = getSheetWithNamespace('DailySales', ss);
   const salesData = entryData.sales || {};
   const paymentBreakdown = entryData.paymentBreakdown || {};
 
-  const deliveryAggregators = Array.isArray(paymentBreakdown.delivery_aggregators)
-    ? paymentBreakdown.delivery_aggregators
-    : [];
-  const deliveryTotal = deliveryAggregators.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
-
   const totalRevenue = parseFloat(salesData.total_revenue) || 0;
   const shawarmaRevenue = parseFloat(salesData.shawarma_revenue) || 0;
-  const otherFoodRevenue = totalRevenue - shawarmaRevenue;
-  const cashSales = parseFloat(paymentBreakdown.cash_sales || salesData.cash_sales) || 0;
-  const cardSales = parseFloat(paymentBreakdown.card_sales || salesData.card_sales) || 0;
-  const aggregator1 = deliveryTotal || parseFloat(salesData.delivery_aggregator_1) || 0;
-  const aggregator2 = 0;
   const estimatedFoodCost = totalRevenue * 0.22;
   const foodCostPercentage = totalRevenue > 0 ? (estimatedFoodCost / totalRevenue) * 100 : 0;
   const totalOrders = 0;
-  const pettyCashTotal = parseFloat(salesData.petty_cash_total) || 0;
 
-  const id = Utilities.getUuid();
+  const salesId = Utilities.getUuid();
+
   const row = [
-    id, entryDate, totalRevenue, shawarmaRevenue, otherFoodRevenue,
-    cashSales, cardSales, aggregator1, aggregator2, estimatedFoodCost,
-    foodCostPercentage, totalOrders, pettyCashTotal, employeeId, new Date(), new Date()
+    salesId, entryDate, totalRevenue, shawarmaRevenue, estimatedFoodCost,
+    foodCostPercentage, totalOrders, employeeId, new Date(), new Date()
   ];
 
   salesSheet.appendRow(row);
-  saveSalesBreakdown(entryDate, id, paymentBreakdown, entryData.pettyCashEntries || []);
-  return id;
+
+  saveSalesBreakdown(entryData, entryDate, employeeId, salesId);
+
+  return salesId;
 }
 
-function saveSalesBreakdown(entryDate, salesId, paymentBreakdown, pettyCashEntries) {
+// Save payment method and cash expense breakdown
+function saveSalesBreakdown(entryData, entryDate, employeeId, salesId) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const breakdownSheet = getSheetWithNamespace('DailySalesBreakdown', ss);
   if (!breakdownSheet) return;
 
-  const cashSales = parseFloat(paymentBreakdown.cash_sales) || 0;
-  const cardSales = parseFloat(paymentBreakdown.card_sales) || 0;
-  const deliveryAggregators = Array.isArray(paymentBreakdown.delivery_aggregators)
-    ? paymentBreakdown.delivery_aggregators
-    : [];
+  const breakdown = entryData.paymentBreakdown || {};
+
+  const cashSales = parseFloat(breakdown.cash_sales) || 0;
+  const cardSales = parseFloat(breakdown.card_sales) || 0;
+  const deliveryAggregators = Array.isArray(breakdown.delivery_aggregators) ? breakdown.delivery_aggregators : [];
   const deliverySales = deliveryAggregators.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
   const aggregatorDetails = JSON.stringify(deliveryAggregators);
-  const pettyCashTotal = Array.isArray(pettyCashEntries)
-    ? pettyCashEntries.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0)
-    : 0;
-  const expenseNotes = paymentBreakdown.aggregator_details || paymentBreakdown.expense_notes || '';
+  const pettyCashTotal = Array.isArray(entryData.pettyCashEntries)
+    ? entryData.pettyCashEntries.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0)
+    : parseFloat(breakdown.cash_expenses) || 0;
+  const expenseNotes = breakdown.expense_notes || '';
 
   const row = [
     Utilities.getUuid(), entryDate, salesId, cashSales, cardSales, deliverySales,
@@ -2101,6 +2117,33 @@ function saveSalesBreakdown(entryDate, salesId, paymentBreakdown, pettyCashEntri
   ];
 
   breakdownSheet.appendRow(row);
+
+  if (Array.isArray(entryData.pettyCashEntries)) {
+    saveDailyPettyCashEntries(entryData.pettyCashEntries, entryDate, salesId, employeeId);
+  }
+}
+
+function saveDailyPettyCashEntries(entries, entryDate, salesId, employeeId) {
+  const sheet = getSheetWithNamespace('DailyPettyCash');
+  if (!sheet) return;
+
+  entries
+    .filter(item => (parseFloat(item.amount) || 0) > 0)
+    .forEach(item => {
+      const row = [
+        Utilities.getUuid(),
+        entryDate,
+        salesId,
+        item.category || '',
+        item.description || '',
+        parseFloat(item.amount) || 0,
+        item.paid_by || 'Cash',
+        new Date(),
+        new Date()
+      ];
+
+      sheet.appendRow(row);
+    });
 }
 
 // Petty cash management functions

--- a/Code.gs
+++ b/Code.gs
@@ -790,79 +790,87 @@ function deleteExistingEntries(dateString) {
       'SnapshotLog'
     ];
 
-    const deletedDailySalesIds = [];
+    const sheetModes = MIGRATION_CONFIG.dualWriteMode ? ['namespaced', 'base'] : ['namespaced'];
 
-    sheetsToClean.forEach(sheetName => {
-      const sheet = getSheetWithNamespace(sheetName, ss);
-      if (!sheet) return;
+    const getSheetByMode = (sheetName, mode) => {
+      return mode === 'base' ? ss.getSheetByName(sheetName) : getSheetWithNamespace(sheetName, ss);
+    };
 
-      const data = sheet.getDataRange().getValues();
-      const headers = data[0];
-      const dateFieldName = sheetName === 'DailyShawarmaStack' || sheetName === 'SnapshotLog' ? 'date' :
-                           sheetName === 'DailySales' ? 'sales_date' : 'count_date';
-      const dateIndex = headers.indexOf(dateFieldName);
+    sheetModes.forEach(mode => {
+      const deletedDailySalesIds = [];
 
-      if (dateIndex === -1) return;
+      sheetsToClean.forEach(sheetName => {
+        const sheet = getSheetByMode(sheetName, mode);
+        if (!sheet) return;
 
-      const rowsToDelete = [];
-      for (let i = data.length - 1; i >= 1; i--) {
-        if (data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate) {
-          rowsToDelete.push(i + 1);
-          if (sheetName === 'DailySales') {
-            const idIndex = headers.indexOf('id');
-            if (idIndex !== -1) {
-              deletedDailySalesIds.push(data[i][idIndex]);
+        const data = sheet.getDataRange().getValues();
+        const headers = data[0];
+        const dateFieldName = sheetName === 'DailyShawarmaStack' || sheetName === 'SnapshotLog' ? 'date' :
+                             sheetName === 'DailySales' ? 'sales_date' : 'count_date';
+        const dateIndex = headers.indexOf(dateFieldName);
+
+        if (dateIndex === -1) return;
+
+        const rowsToDelete = [];
+        for (let i = data.length - 1; i >= 1; i--) {
+          if (data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate) {
+            rowsToDelete.push(i + 1);
+            if (sheetName === 'DailySales') {
+              const idIndex = headers.indexOf('id');
+              if (idIndex !== -1) {
+                deletedDailySalesIds.push(data[i][idIndex]);
+              }
             }
           }
         }
-      }
 
-      rowsToDelete.forEach(rowIndex => {
-        sheet.deleteRow(rowIndex);
+        rowsToDelete.forEach(rowIndex => {
+          sheet.deleteRow(rowIndex);
+        });
       });
-    });
 
-    const cleanupRelatedSheet = (sheetName, dateField, idField) => {
-      const sheet = getSheetWithNamespace(sheetName, ss);
-      if (!sheet || sheet.getLastRow() <= 1) return;
+      const cleanupRelatedSheet = (sheetName, dateField, idField) => {
+        const sheet = getSheetByMode(sheetName, mode);
+        if (!sheet || sheet.getLastRow() <= 1) return;
 
-      const data = sheet.getDataRange().getValues();
-      const headers = data[0];
-      const dateIndex = headers.indexOf(dateField);
-      const idIndex = headers.indexOf(idField);
-      const rowsToDelete = [];
+        const data = sheet.getDataRange().getValues();
+        const headers = data[0];
+        const dateIndex = headers.indexOf(dateField);
+        const idIndex = headers.indexOf(idField);
+        const rowsToDelete = [];
 
-      for (let i = data.length - 1; i >= 1; i--) {
-        const matchesDate = dateIndex !== -1 && data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate;
-        const matchesId = idIndex !== -1 && deletedDailySalesIds.indexOf(data[i][idIndex]) !== -1;
-        if (matchesDate || matchesId) {
-          rowsToDelete.push(i + 1);
-        }
-      }
-
-      rowsToDelete.forEach(rowIndex => sheet.deleteRow(rowIndex));
-    };
-
-    cleanupRelatedSheet('DailySalesBreakdown', 'sales_date', 'daily_sales_id');
-    cleanupRelatedSheet('DailyPettyCash', 'sales_date', 'daily_sales_id');
-
-    if (deletedDailySalesIds.length > 0) {
-      const pettySheet = getSheetWithNamespace('PettyCashDetail', ss);
-      if (pettySheet && pettySheet.getLastRow() > 1) {
-        const pettyData = pettySheet.getDataRange().getValues();
-        const pettyHeaders = pettyData[0];
-        const dailyIdIndex = pettyHeaders.indexOf('daily_sales_id');
-        const pettyRowsToDelete = [];
-        for (let j = pettyData.length - 1; j >= 1; j--) {
-          if (dailyIdIndex !== -1 && deletedDailySalesIds.indexOf(pettyData[j][dailyIdIndex]) !== -1) {
-            pettyRowsToDelete.push(j + 1);
+        for (let i = data.length - 1; i >= 1; i--) {
+          const matchesDate = dateIndex !== -1 && data[i][dateIndex] && new Date(data[i][dateIndex]).toDateString() === targetDate;
+          const matchesId = idIndex !== -1 && deletedDailySalesIds.indexOf(data[i][idIndex]) !== -1;
+          if (matchesDate || matchesId) {
+            rowsToDelete.push(i + 1);
           }
         }
-        pettyRowsToDelete.forEach(rowIndex => {
-          pettySheet.deleteRow(rowIndex);
-        });
+
+        rowsToDelete.forEach(rowIndex => sheet.deleteRow(rowIndex));
+      };
+
+      cleanupRelatedSheet('DailySalesBreakdown', 'sales_date', 'daily_sales_id');
+      cleanupRelatedSheet('DailyPettyCash', 'sales_date', 'daily_sales_id');
+
+      if (deletedDailySalesIds.length > 0) {
+        const pettySheet = getSheetByMode('PettyCashDetail', mode);
+        if (pettySheet && pettySheet.getLastRow() > 1) {
+          const pettyData = pettySheet.getDataRange().getValues();
+          const pettyHeaders = pettyData[0];
+          const dailyIdIndex = pettyHeaders.indexOf('daily_sales_id');
+          const pettyRowsToDelete = [];
+          for (let j = pettyData.length - 1; j >= 1; j--) {
+            if (dailyIdIndex !== -1 && deletedDailySalesIds.indexOf(pettyData[j][dailyIdIndex]) !== -1) {
+              pettyRowsToDelete.push(j + 1);
+            }
+          }
+          pettyRowsToDelete.forEach(rowIndex => {
+            pettySheet.deleteRow(rowIndex);
+          });
+        }
       }
-    }
+    });
 
   } catch (error) {
     Logger.log('Error deleting existing entries: ' + error.toString());
@@ -955,7 +963,7 @@ function saveDailyEntryToNewTables(entryData) {
 
   let dailySalesId = null;
   if (entryData.sales || (entryData.pettyCashEntries && entryData.pettyCashEntries.length)) {
-    dailySalesId = saveEnhancedSalesData(entryData, entryDate, employeeId);
+    dailySalesId = saveEnhancedSalesData(entryData, entryDate, employeeId, { skipNamespace: false });
   }
 
   if (entryData.pettyCashEntries && entryData.pettyCashEntries.length && dailySalesId) {
@@ -1007,7 +1015,7 @@ function saveToOldShawarmaTable(entryData, entryDate, employeeId) {
 }
 
 function saveToOldSalesTable(entryData, entryDate, employeeId) {
-  saveEnhancedSalesData(entryData, entryDate, employeeId);
+  saveEnhancedSalesData(entryData, entryDate, employeeId, { skipNamespace: true });
 }
 
 function saveToOldInventoryTables(inventoryData, entryDate, employeeId, employeeName) {
@@ -1226,14 +1234,14 @@ function saveShawarmaStackData(entryData, entryDate, employeeId) {
   shawarmaSheet.appendRow(row);
 }
 
-function saveEnhancedSalesData(entryData, entryDate, employeeId) {
+function saveEnhancedSalesData(entryData, entryDate, employeeId, options = {}) {
   if (entryData.pettyCashEntries && entryData.pettyCashEntries.length) {
     const pettyTotal = calculatePettyCashTotal(entryData.pettyCashEntries);
     entryData.sales = entryData.sales || {};
     entryData.sales.petty_cash_total = pettyTotal;
   }
   if (entryData.sales) {
-    return saveSalesData(entryData, entryDate, employeeId);
+    return saveSalesData(entryData, entryDate, employeeId, options);
   }
   return null;
 }
@@ -2067,9 +2075,9 @@ function saveHighCostItemsData(entryData, entryDate, employeeId) {
 }
 
 // Save Sales Data with payment breakdown linkage
-function saveSalesData(entryData, entryDate, employeeId) {
+function saveSalesData(entryData, entryDate, employeeId, options = {}) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const salesSheet = getSheetWithNamespace('DailySales', ss);
+  const salesSheet = options.skipNamespace ? ss.getSheetByName('DailySales') : getSheetWithNamespace('DailySales', ss);
   const salesData = entryData.sales || {};
   const paymentBreakdown = entryData.paymentBreakdown || {};
 
@@ -2088,15 +2096,15 @@ function saveSalesData(entryData, entryDate, employeeId) {
 
   salesSheet.appendRow(row);
 
-  saveSalesBreakdown(entryData, entryDate, employeeId, salesId);
+  saveSalesBreakdown(entryData, entryDate, employeeId, salesId, options);
 
   return salesId;
 }
 
 // Save payment method and cash expense breakdown
-function saveSalesBreakdown(entryData, entryDate, employeeId, salesId) {
+function saveSalesBreakdown(entryData, entryDate, employeeId, salesId, options = {}) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
-  const breakdownSheet = getSheetWithNamespace('DailySalesBreakdown', ss);
+  const breakdownSheet = options.skipNamespace ? ss.getSheetByName('DailySalesBreakdown') : getSheetWithNamespace('DailySalesBreakdown', ss);
   if (!breakdownSheet) return;
 
   const breakdown = entryData.paymentBreakdown || {};
@@ -2119,12 +2127,12 @@ function saveSalesBreakdown(entryData, entryDate, employeeId, salesId) {
   breakdownSheet.appendRow(row);
 
   if (Array.isArray(entryData.pettyCashEntries)) {
-    saveDailyPettyCashEntries(entryData.pettyCashEntries, entryDate, salesId, employeeId);
+    saveDailyPettyCashEntries(entryData.pettyCashEntries, entryDate, salesId, employeeId, options);
   }
 }
 
-function saveDailyPettyCashEntries(entries, entryDate, salesId, employeeId) {
-  const sheet = getSheetWithNamespace('DailyPettyCash');
+function saveDailyPettyCashEntries(entries, entryDate, salesId, employeeId, options = {}) {
+  const sheet = options.skipNamespace ? SpreadsheetApp.getActiveSpreadsheet().getSheetByName('DailyPettyCash') : getSheetWithNamespace('DailyPettyCash');
   if (!sheet) return;
 
   entries

--- a/Code.gs
+++ b/Code.gs
@@ -1308,10 +1308,16 @@ function generateReportFromNewTables(targetDateString) {
   try {
     const shawarmaData = Array.isArray(getSheetData('DailyShawarmaStack')) ? getSheetData('DailyShawarmaStack') : [];
     const salesData = Array.isArray(getSheetData('DailySales')) ? getSheetData('DailySales') : [];
+    const salesBreakdownData = Array.isArray(getSheetData('DailySalesBreakdown')) ? getSheetData('DailySalesBreakdown') : [];
     const snapshotData = Array.isArray(getSheetData('SnapshotLog')) ? getSheetData('SnapshotLog') : [];
 
     const todayShawarma = shawarmaData.find(row => row.date && new Date(row.date).toDateString() === targetDateString);
     const todaySales = salesData.find(row => row.sales_date && new Date(row.sales_date).toDateString() === targetDateString);
+
+    let todayBreakdown = null;
+    if (todaySales && todaySales.id && salesBreakdownData.length) {
+      todayBreakdown = salesBreakdownData.find(row => row.daily_sales_id === todaySales.id) || null;
+    }
 
     let pettyCashEntries = [];
     if (todaySales && todaySales.id) {
@@ -1334,6 +1340,7 @@ function generateReportFromNewTables(targetDateString) {
       dataFound: !!(todayShawarma || todaySales || todaySnapshot.length > 0),
       shawarma: todayShawarma || null,
       sales: todaySales || null,
+      salesBreakdown: todayBreakdown,
       inventory: inventoryData,
       pettyCashEntries: pettyCashEntries,
       notes: ''
@@ -1348,6 +1355,7 @@ function generateReportFromNewTables(targetDateString) {
       dataFound: false,
       shawarma: null,
       sales: null,
+      salesBreakdown: null,
       inventory: null,
       pettyCashEntries: [],
       notes: ''
@@ -2038,15 +2046,21 @@ function saveHighCostItemsData(entryData, entryDate, employeeId) {
 function saveSalesData(entryData, entryDate, employeeId) {
   const ss = SpreadsheetApp.getActiveSpreadsheet();
   const salesSheet = ss.getSheetByName('DailySales');
-  const salesData = entryData.sales;
-  
+  const salesData = entryData.sales || {};
+  const paymentBreakdown = entryData.paymentBreakdown || {};
+
+  const deliveryAggregators = Array.isArray(paymentBreakdown.delivery_aggregators)
+    ? paymentBreakdown.delivery_aggregators
+    : [];
+  const deliveryTotal = deliveryAggregators.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
+
   const totalRevenue = parseFloat(salesData.total_revenue) || 0;
   const shawarmaRevenue = parseFloat(salesData.shawarma_revenue) || 0;
   const otherFoodRevenue = totalRevenue - shawarmaRevenue;
-  const cashSales = parseFloat(salesData.cash_sales) || 0;
-  const cardSales = parseFloat(salesData.card_sales) || 0;
-  const aggregator1 = parseFloat(salesData.delivery_aggregator_1) || 0;
-  const aggregator2 = parseFloat(salesData.delivery_aggregator_2) || 0;
+  const cashSales = parseFloat(paymentBreakdown.cash_sales || salesData.cash_sales) || 0;
+  const cardSales = parseFloat(paymentBreakdown.card_sales || salesData.card_sales) || 0;
+  const aggregator1 = deliveryTotal || parseFloat(salesData.delivery_aggregator_1) || 0;
+  const aggregator2 = 0;
   const estimatedFoodCost = totalRevenue * 0.22;
   const foodCostPercentage = totalRevenue > 0 ? (estimatedFoodCost / totalRevenue) * 100 : 0;
   const totalOrders = 0;
@@ -2060,7 +2074,33 @@ function saveSalesData(entryData, entryDate, employeeId) {
   ];
 
   salesSheet.appendRow(row);
+  saveSalesBreakdown(entryDate, id, paymentBreakdown, entryData.pettyCashEntries || []);
   return id;
+}
+
+function saveSalesBreakdown(entryDate, salesId, paymentBreakdown, pettyCashEntries) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const breakdownSheet = getSheetWithNamespace('DailySalesBreakdown', ss);
+  if (!breakdownSheet) return;
+
+  const cashSales = parseFloat(paymentBreakdown.cash_sales) || 0;
+  const cardSales = parseFloat(paymentBreakdown.card_sales) || 0;
+  const deliveryAggregators = Array.isArray(paymentBreakdown.delivery_aggregators)
+    ? paymentBreakdown.delivery_aggregators
+    : [];
+  const deliverySales = deliveryAggregators.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
+  const aggregatorDetails = JSON.stringify(deliveryAggregators);
+  const pettyCashTotal = Array.isArray(pettyCashEntries)
+    ? pettyCashEntries.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0)
+    : 0;
+  const expenseNotes = paymentBreakdown.aggregator_details || paymentBreakdown.expense_notes || '';
+
+  const row = [
+    Utilities.getUuid(), entryDate, salesId, cashSales, cardSales, deliverySales,
+    aggregatorDetails, pettyCashTotal, expenseNotes, new Date(), new Date()
+  ];
+
+  breakdownSheet.appendRow(row);
 }
 
 // Petty cash management functions

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -399,6 +399,7 @@ function DailyEntryTab() {
     });
     
     const [loading, setLoading] = React.useState(false);
+    const [aggregatorOptions, setAggregatorOptions] = React.useState([]);
     const [calculatedMetrics, setCalculatedMetrics] = React.useState(null);
     const [selectedDate, setSelectedDate] = React.useState(new Date().toISOString().split('T')[0]);
     const [existingEntry, setExistingEntry] = React.useState(null);
@@ -437,8 +438,40 @@ function DailyEntryTab() {
         });
     };
 
+    const getAggregatorLabel = (index) => {
+        const fallbackKey = index === 0 ? 'deliveryAggregator1' : 'deliveryAggregator2';
+        return (aggregatorOptions[index] && aggregatorOptions[index].name) ? aggregatorOptions[index].name : t(fallbackKey);
+    };
+
     React.useEffect(() => {
         validateTranslations();
+    }, []);
+
+    React.useEffect(() => {
+        const applyAggregators = (list) => {
+            const active = (list || []).filter(item => item.active !== false);
+            setAggregatorOptions(active);
+        };
+
+        google.script.run
+            .withSuccessHandler(result => {
+                try {
+                    const parsed = Array.isArray(result)
+                        ? result
+                        : (typeof result === 'string' && result.trim())
+                            ? JSON.parse(result)
+                            : [];
+                    applyAggregators(parsed);
+                } catch (error) {
+                    console.error('Failed to parse aggregator settings', error);
+                    applyAggregators([]);
+                }
+            })
+            .withFailureHandler(err => {
+                console.error('Failed to load aggregators', err);
+                applyAggregators([]);
+            })
+            .getAggregatorSettings(false);
     }, []);
 
     const INVENTORY_CONFIG = {
@@ -1963,7 +1996,7 @@ function DailyEntryTab() {
                         ),
                         // Delivery platform 1
                         React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('deliveryAggregator1')),
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(0)),
                             React.createElement('input', {
                                 type: 'number',
                                 step: '0.01',
@@ -1975,7 +2008,7 @@ function DailyEntryTab() {
                         ),
                         // Delivery platform 2
                         React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('deliveryAggregator2')),
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(1)),
                             React.createElement('input', {
                                 type: 'number',
                                 step: '0.01',

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -462,6 +462,46 @@ function DailyEntryTab() {
         }));
     };
 
+    const buildEmptyPaymentBreakdown = React.useCallback(() => ({
+        cash_sales: '',
+        card_sales: '',
+        delivery_aggregators: (aggregatorOptions || []).map(item => ({ ...item, amount: '' })),
+        aggregator_details: ''
+    }), [aggregatorOptions]);
+
+    const clearEntryValues = React.useCallback(() => {
+        setFormData(prev => ({
+            ...prev,
+            shawarmaStack: { starting_weight: '', remaining_weight: '', shaving_weight: '', staff_meals_weight: '', orders_weight: '' },
+            rawProteins: {
+                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
+                chicken_shawarma_opening: '', chicken_shawarma_received: '', chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
+                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
+            },
+            marinatedProteins: {
+                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
+                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
+                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
+                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
+                marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
+            },
+            bread: {
+                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
+                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
+                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
+            },
+            highCostItems: {
+                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
+                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
+            },
+            sales: {
+                total_revenue: '', shawarma_revenue: '', other_food_revenue: '', petty_cash_total: ''
+            }
+        }));
+        setPaymentBreakdown(buildEmptyPaymentBreakdown());
+        setPettyCashEntries([]);
+    }, [buildEmptyPaymentBreakdown]);
+
     React.useEffect(() => {
         validateTranslations();
     }, []);
@@ -470,10 +510,20 @@ function DailyEntryTab() {
         const applyAggregators = (list) => {
             const active = (list || []).filter(item => item.active !== false);
             setAggregatorOptions(active);
-            setPaymentBreakdown(prev => ({
-                ...prev,
-                delivery_aggregators: active.map(item => ({ ...item, amount: '' }))
-            }));
+            setPaymentBreakdown(prev => {
+                const existing = prev.delivery_aggregators || [];
+                const mapped = active.map(option => {
+                    const matched = existing.find(item => item.id === option.id || item.name === option.name);
+                    return { ...option, amount: matched ? matched.amount || '' : '' };
+                });
+                const hasExistingAmounts = mapped.some(item => item.amount && String(item.amount).trim() !== '');
+
+                return {
+                    ...prev,
+                    delivery_aggregators: mapped.length ? mapped : active.map(item => ({ ...item, amount: '' })),
+                    aggregator_details: hasExistingAmounts ? (prev.aggregator_details || '') : ''
+                };
+            });
         };
 
         google.script.run
@@ -639,6 +689,7 @@ function DailyEntryTab() {
                         setDuplicateWarning(true);
                         setFieldsLocked(true);
                         setShowLoadExistingPin(true);
+                        clearEntryValues();
                     } else {
                         resetFormToClean();
                     }
@@ -1009,50 +1060,7 @@ function DailyEntryTab() {
     };
     
     const resetForm = () => {
-        setFormData({
-            shawarmaStack: {
-                starting_weight: '', remaining_weight: '', shaving_weight: '',
-                staff_meals_weight: '', orders_weight: ''
-            },
-            rawProteins: {
-                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', 
-                frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
-                chicken_shawarma_opening: '', chicken_shawarma_received: '', 
-                chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
-                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
-            },
-            marinatedProteins: {
-                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
-                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
-                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
-                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
-    // ADD THIS LINE:
-    marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
-            },
-            bread: {
-                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
-                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
-                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
-            },
-            highCostItems: {
-                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
-                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
-            },
-            sales: {
-                total_revenue: '',
-                shawarma_revenue: '',
-                other_food_revenue: '',
-                petty_cash_total: ''
-            },
-            paymentBreakdown: {
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregators: aggregatorOptions.map(a => ({ ...a, amount: '' })),
-                aggregator_details: ''
-            },
-            notes: ''
-        });
-        setPettyCashEntries([]);
+        clearEntryValues();
         setIsUpdateMode(false);
     };
     
@@ -1113,15 +1121,32 @@ function DailyEntryTab() {
                                         cash_sales: data.salesBreakdown ? String(data.salesBreakdown.cash_sales || '') : (data.sales ? String(data.sales.cash_sales || '') : ''),
                                         card_sales: data.salesBreakdown ? String(data.salesBreakdown.card_sales || '') : (data.sales ? String(data.sales.card_sales || '') : ''),
                                         delivery_aggregators: (() => {
-                                            try {
-                                                const parsed = data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
-                                                return aggregatorOptions.map(option => {
-                                                    const matched = parsed.find(p => p.id === option.id || p.name === option.name);
-                                                    return { ...option, amount: matched ? String(matched.amount || '') : '' };
-                                                });
-                                            } catch (error) {
-                                                return aggregatorOptions.map(option => ({ ...option, amount: '' }));
+                                            const parsed = (() => {
+                                                try {
+                                                    return data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
+                                                } catch (error) {
+                                                    return [];
+                                                }
+                                            })();
+
+                                            const sourceAggregators = (aggregatorOptions && aggregatorOptions.length) ? aggregatorOptions : parsed;
+                                            let resolved = sourceAggregators.map(option => {
+                                                const matched = parsed.find(p => p.id === option.id || p.name === option.name);
+                                                return { ...option, amount: matched ? String(matched.amount || '') : '' };
+                                            });
+
+                                            if (!resolved.length && parsed.length) {
+                                                resolved = parsed.map(item => ({ ...item, amount: String(item.amount || '') }));
                                             }
+
+                                            if (!resolved.length && data.sales && (data.sales.delivery_aggregator_1 || data.sales.delivery_sales)) {
+                                                const fallbackTotal = String(data.sales.delivery_aggregator_1 || data.sales.delivery_sales || '');
+                                                const baseOption = sourceAggregators[0] || { id: 'delivery_fallback', name: 'Delivery Aggregators' };
+                                                return [{ ...baseOption, amount: fallbackTotal }];
+                                            }
+
+                                            const emptyAggregators = buildEmptyPaymentBreakdown().delivery_aggregators;
+                                            return resolved.length ? resolved : emptyAggregators;
                                         })(),
                                         aggregator_details: data.salesBreakdown ? String(data.salesBreakdown.aggregator_details || '') : ''
                                     },
@@ -1223,59 +1248,21 @@ function DailyEntryTab() {
         }
     };
 
+
     const resetFormToClean = () => {
-        setFormData({
-            shawarmaStack: {
-                starting_weight: '', remaining_weight: '', shaving_weight: '',
-                staff_meals_weight: '', orders_weight: ''
-            },
-            rawProteins: {
-                frozen_chicken_breast_opening: '', frozen_chicken_breast_received: '', 
-                frozen_chicken_breast_expired: '', frozen_chicken_breast_remaining: '',
-                chicken_shawarma_opening: '', chicken_shawarma_received: '', 
-                chicken_shawarma_expired: '', chicken_shawarma_remaining: '',
-                steak_opening: '', steak_received: '', steak_expired: '', steak_remaining: ''
-            },
-            marinatedProteins: {
-                fahita_chicken_opening: '', fahita_chicken_received: '', fahita_chicken_expired: '', fahita_chicken_remaining: '',
-                chicken_sub_opening: '', chicken_sub_received: '', chicken_sub_expired: '', chicken_sub_remaining: '',
-                spicy_strips_opening: '', spicy_strips_received: '', spicy_strips_expired: '', spicy_strips_remaining: '',
-                original_strips_opening: '', original_strips_received: '', original_strips_expired: '', original_strips_remaining: '',
-    // ADD THIS LINE:
-    marinated_steak_opening: '', marinated_steak_received: '', marinated_steak_expired: '', marinated_steak_remaining: ''
-            },
-            bread: {
-                saj_bread_opening: '', saj_bread_received: '', saj_bread_expired: '', saj_bread_remaining: '',
-                pita_bread_opening: '', pita_bread_received: '', pita_bread_expired: '', pita_bread_remaining: '',
-                bread_rolls_opening: '', bread_rolls_received: '', bread_rolls_expired: '', bread_rolls_remaining: ''
-            },
-            highCostItems: {
-                cream_opening: '', cream_received: '', cream_expired: '', cream_remaining: '',
-                mayo_opening: '', mayo_received: '', mayo_expired: '', mayo_remaining: ''
-            },
-            sales: {
-                total_revenue: '',
-                shawarma_revenue: '',
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregator_1: '',
-                delivery_aggregator_2: '',
-                other_food_revenue: '',
-                petty_cash_total: ''
-            },
-            notes: ''
-        });
+        clearEntryValues();
 
         setDuplicateWarning(false);
         setIsUpdateMode(false);
-        setPettyCashEntries([]);
         setFieldsLocked(false);
+        setShowPinInput(false);
+        setManagementPin('');
         setShowLoadExistingPin(false);
         setLoadExistingPin('');
-        setLoadingExistingData(false);
         setPinError(false);
         setPinAttempted(false);
     };
+
     
     const cancelLoadExisting = () => {
         setShowLoadExistingPin(false);
@@ -2040,10 +2027,7 @@ function DailyEntryTab() {
                             React.createElement('div', { className: 'space-y-2' },
                                 (paymentBreakdown.delivery_aggregators || []).map(item => (
                                     React.createElement('div', { key: item.id, className: 'border rounded p-3 bg-white shadow-sm flex items-center justify-between' },
-                                        React.createElement('div', null,
-                                            React.createElement('p', { className: 'text-sm font-medium text-gray-800' }, item.name || 'Aggregator'),
-                                            React.createElement('p', { className: 'text-xs text-gray-500' }, `Commission: ${item.commission_percent || 0}%`)
-                                        ),
+                                        React.createElement('p', { className: 'text-sm font-medium text-gray-800 mb-1 md:mb-0' }, item.name || 'Aggregator'),
                                         React.createElement('div', { className: 'w-32' },
                                             React.createElement('input', {
                                                 type: 'number',

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -386,12 +386,15 @@ function DailyEntryTab() {
         sales: {
             total_revenue: '',
             shawarma_revenue: '',
-            cash_sales: '',
-            card_sales: '',
-            delivery_aggregator_1: '',
-            delivery_aggregator_2: '',
             other_food_revenue: '',
             petty_cash_total: ''
+        },
+
+        paymentBreakdown: {
+            cash_sales: '',
+            card_sales: '',
+            delivery_aggregators: [],
+            aggregator_details: ''
         },
         
         // Notes
@@ -400,6 +403,12 @@ function DailyEntryTab() {
     
     const [loading, setLoading] = React.useState(false);
     const [aggregatorOptions, setAggregatorOptions] = React.useState([]);
+    const [paymentBreakdown, setPaymentBreakdown] = React.useState({
+        cash_sales: '',
+        card_sales: '',
+        delivery_aggregators: [],
+        aggregator_details: ''
+    });
     const [calculatedMetrics, setCalculatedMetrics] = React.useState(null);
     const [selectedDate, setSelectedDate] = React.useState(new Date().toISOString().split('T')[0]);
     const [existingEntry, setExistingEntry] = React.useState(null);
@@ -443,6 +452,16 @@ function DailyEntryTab() {
         return (aggregatorOptions[index] && aggregatorOptions[index].name) ? aggregatorOptions[index].name : t(fallbackKey);
     };
 
+    const updateAggregatorAmount = (id, value) => {
+        const normalized = normalizeNumberInput(value);
+        setPaymentBreakdown(prev => ({
+            ...prev,
+            delivery_aggregators: (prev.delivery_aggregators || []).map(item =>
+                item.id === id ? { ...item, amount: normalized } : item
+            )
+        }));
+    };
+
     React.useEffect(() => {
         validateTranslations();
     }, []);
@@ -451,6 +470,10 @@ function DailyEntryTab() {
         const applyAggregators = (list) => {
             const active = (list || []).filter(item => item.active !== false);
             setAggregatorOptions(active);
+            setPaymentBreakdown(prev => ({
+                ...prev,
+                delivery_aggregators: active.map(item => ({ ...item, amount: '' }))
+            }));
         };
 
         google.script.run
@@ -940,8 +963,16 @@ function DailyEntryTab() {
                 },
                 sales: {
                     ...formData.sales,
+                    cash_sales: paymentBreakdown.cash_sales,
+                    card_sales: paymentBreakdown.card_sales,
+                    delivery_aggregator_1: calculateDeliveryTotal(),
+                    delivery_aggregator_2: 0,
                     other_food_revenue: calculateOtherFoodRevenue(),
                     petty_cash_total: calculatePettyCashTotal()
+                },
+                paymentBreakdown: {
+                    ...paymentBreakdown,
+                    delivery_aggregators: paymentBreakdown.delivery_aggregators || []
                 },
                 pettyCashEntries: pettyCashEntries,
                 inventory: inventory,
@@ -1010,12 +1041,14 @@ function DailyEntryTab() {
             sales: {
                 total_revenue: '',
                 shawarma_revenue: '',
-                cash_sales: '',
-                card_sales: '',
-                delivery_aggregator_1: '',
-                delivery_aggregator_2: '',
                 other_food_revenue: '',
                 petty_cash_total: ''
+            },
+            paymentBreakdown: {
+                cash_sales: '',
+                card_sales: '',
+                delivery_aggregators: aggregatorOptions.map(a => ({ ...a, amount: '' })),
+                aggregator_details: ''
             },
             notes: ''
         });
@@ -1073,12 +1106,24 @@ function DailyEntryTab() {
                                     sales: {
                                         total_revenue: data.sales ? String(data.sales.total_revenue || '') : '',
                                         shawarma_revenue: data.sales ? String(data.sales.shawarma_revenue || '') : '',
-                                        cash_sales: data.sales ? String(data.sales.cash_sales || '') : '',
-                                        card_sales: data.sales ? String(data.sales.card_sales || '') : '',
-                                        delivery_aggregator_1: data.sales ? String(data.sales.delivery_aggregator_1 || '') : '',
-                                        delivery_aggregator_2: data.sales ? String(data.sales.delivery_aggregator_2 || '') : '',
                                         other_food_revenue: data.sales ? String(data.sales.other_food_revenue || '') : '',
                                         petty_cash_total: data.sales ? String(data.sales.petty_cash_total || '') : ''
+                                    },
+                                    paymentBreakdown: {
+                                        cash_sales: data.salesBreakdown ? String(data.salesBreakdown.cash_sales || '') : (data.sales ? String(data.sales.cash_sales || '') : ''),
+                                        card_sales: data.salesBreakdown ? String(data.salesBreakdown.card_sales || '') : (data.sales ? String(data.sales.card_sales || '') : ''),
+                                        delivery_aggregators: (() => {
+                                            try {
+                                                const parsed = data.salesBreakdown && data.salesBreakdown.aggregator_details ? JSON.parse(data.salesBreakdown.aggregator_details) : [];
+                                                return aggregatorOptions.map(option => {
+                                                    const matched = parsed.find(p => p.id === option.id || p.name === option.name);
+                                                    return { ...option, amount: matched ? String(matched.amount || '') : '' };
+                                                });
+                                            } catch (error) {
+                                                return aggregatorOptions.map(option => ({ ...option, amount: '' }));
+                                            }
+                                        })(),
+                                        aggregator_details: data.salesBreakdown ? String(data.salesBreakdown.aggregator_details || '') : ''
                                     },
                                     rawProteins: {
                                         frozen_chicken_breast_opening: String(inventoryData.rawProteins.frozen_chicken_breast_opening || ''),
@@ -1251,6 +1296,10 @@ function DailyEntryTab() {
 
     const calculatePettyCashTotal = () => {
         return pettyCashEntries.reduce((sum, entry) => sum + (parseFloat(entry.amount) || 0), 0);
+    };
+
+    const calculateDeliveryTotal = () => {
+        return (paymentBreakdown.delivery_aggregators || []).reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
     };
 
     const handleAddPettyCashEntry = () => {
@@ -1970,51 +2019,53 @@ function DailyEntryTab() {
                             }),
                             React.createElement('p', { className: 'text-xs text-gray-500 mt-1' }, 'Used for shawarma profitability calculations')
                         ),
-                        // Cash sales
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('cashSales')),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.cash_sales,
-                                onChange: e => handleInputChange('sales', 'cash_sales', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
+                        // Cash and card sales
+                        ['cash_sales', 'card_sales'].map(key => (
+                            React.createElement('div', { key },
+                                React.createElement('label', { className: 'block text-sm font-medium mb-1' },
+                                    key === 'cash_sales' ? t('cashSales') : t('cardSales')
+                                ),
+                                React.createElement('input', {
+                                    type: 'number',
+                                    step: '0.01',
+                                    value: paymentBreakdown[key],
+                                    onChange: e => setPaymentBreakdown(prev => ({ ...prev, [key]: normalizeNumberInput(e.target.value) })),
+                                    className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                    disabled: fieldsLocked
+                                })
+                            )
+                        )),
+                        React.createElement('div', { className: 'md:col-span-2' },
+                            React.createElement('label', { className: 'block text-sm font-medium mb-2' }, 'Delivery Aggregators'),
+                            React.createElement('div', { className: 'space-y-2' },
+                                (paymentBreakdown.delivery_aggregators || []).map(item => (
+                                    React.createElement('div', { key: item.id, className: 'border rounded p-3 bg-white shadow-sm flex items-center justify-between' },
+                                        React.createElement('div', null,
+                                            React.createElement('p', { className: 'text-sm font-medium text-gray-800' }, item.name || 'Aggregator'),
+                                            React.createElement('p', { className: 'text-xs text-gray-500' }, `Commission: ${item.commission_percent || 0}%`)
+                                        ),
+                                        React.createElement('div', { className: 'w-32' },
+                                            React.createElement('input', {
+                                                type: 'number',
+                                                step: '0.01',
+                                                value: item.amount,
+                                                onChange: e => updateAggregatorAmount(item.id, e.target.value),
+                                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                                disabled: fieldsLocked
+                                            })
+                                        )
+                                    )
+                                ))
+                            )
                         ),
-                        // Card sales
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, t('cardSales')),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.card_sales,
-                                onChange: e => handleInputChange('sales', 'card_sales', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
-                        ),
-                        // Delivery platform 1
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(0)),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.delivery_aggregator_1,
-                                onChange: e => handleInputChange('sales', 'delivery_aggregator_1', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
-                                disabled: fieldsLocked
-                            })
-                        ),
-                        // Delivery platform 2
-                        React.createElement('div', null,
-                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, getAggregatorLabel(1)),
-                            React.createElement('input', {
-                                type: 'number',
-                                step: '0.01',
-                                value: formData.sales.delivery_aggregator_2,
-                                onChange: e => handleInputChange('sales', 'delivery_aggregator_2', e.target.value),
-                                className: 'w-full p-2 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                        React.createElement('div', { className: 'md:col-span-2' },
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Aggregator Notes'),
+                            React.createElement('textarea', {
+                                value: paymentBreakdown.aggregator_details,
+                                onChange: e => setPaymentBreakdown(prev => ({ ...prev, aggregator_details: e.target.value })),
+                                className: 'w-full p-3 border rounded focus:ring-2 focus:ring-olive-500' + (fieldsLocked ? ' bg-gray-100' : ''),
+                                rows: '2',
+                                placeholder: 'e.g., Talabat 1200, Snoonu 900',
                                 disabled: fieldsLocked
                             })
                         ),

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -16,6 +16,8 @@ function ManagementDashboard() {
     });
     const [showDataStatus, setShowDataStatus] = React.useState(false);
     const [showDebugData, setShowDebugData] = React.useState(false);
+    const [aggregators, setAggregators] = React.useState([]);
+    const [aggregatorSaving, setAggregatorSaving] = React.useState(false);
 
     React.useEffect(() => {
         if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
@@ -23,12 +25,46 @@ function ManagementDashboard() {
         }
     }, [selectedPeriod, customDate]);
 
+    React.useEffect(() => {
+        google.script.run
+            .withSuccessHandler(data => {
+                try {
+                    const parsed = JSON.parse(data) || [];
+                    setAggregators(parsed);
+                } catch (error) {
+                    console.error('Failed to parse aggregators', error);
+                }
+            })
+            .withFailureHandler(err => console.error('Failed to load aggregators', err))
+            .getAggregatorSettings();
+    }, []);
+
     const getAcceptableRemainingRange = (stackWeightKg) => {
         return {
             min: 0.6,
             max: 0.85,
             optimal: Math.min(0.8, stackWeightKg * 0.06)
         };
+    };
+
+    const addAggregatorRow = () => {
+        const tempId = `new-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        setAggregators(prev => [...prev, { id: tempId, name: '', commission_percent: '', active: true }]);
+    };
+
+    const updateAggregator = (id, key, value) => {
+        setAggregators(prev => prev.map(item => (item.id === id ? { ...item, [key]: value } : item)));
+    };
+
+    const saveAggregators = () => {
+        setAggregatorSaving(true);
+        google.script.run
+            .withSuccessHandler(() => setAggregatorSaving(false))
+            .withFailureHandler(err => {
+                console.error('Save aggregators failed', err);
+                setAggregatorSaving(false);
+            })
+            .saveAggregatorSettings(JSON.stringify(aggregators));
     };
 
     const getAcceptableLossRange = () => {
@@ -811,6 +847,83 @@ function ManagementDashboard() {
                             Refresh
                         </button>
                     </div>
+                </div>
+            </div>
+
+            {/* Delivery Aggregators */}
+            <div className="bg-white rounded-lg shadow p-6">
+                <div className="flex flex-wrap justify-between items-center gap-4 mb-4">
+                    <div>
+                        <h2 className="text-lg font-semibold text-gray-800">Delivery Aggregators</h2>
+                        <p className="text-sm text-gray-600">Manage aggregator names and commission percentages</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={addAggregatorRow}
+                            className="px-4 py-2 bg-white border border-olive-600 text-olive-700 rounded hover:bg-olive-50 text-sm"
+                        >
+                            Add Aggregator
+                        </button>
+                        <button
+                            onClick={saveAggregators}
+                            disabled={aggregatorSaving}
+                            className="px-4 py-2 bg-olive-600 text-white rounded hover:bg-olive-700 text-sm disabled:opacity-50"
+                        >
+                            {aggregatorSaving ? 'Saving...' : 'Save Changes'}
+                        </button>
+                    </div>
+                </div>
+
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                            <tr>
+                                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Commission %</th>
+                                <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Active</th>
+                            </tr>
+                        </thead>
+                        <tbody className="bg-white divide-y divide-gray-200">
+                            {aggregators.map((item, idx) => (
+                                <tr key={item.id || idx}>
+                                    <td className="px-3 py-2">
+                                        <input
+                                            type="text"
+                                            value={item.name || ''}
+                                            onChange={e => updateAggregator(item.id, 'name', e.target.value)}
+                                            className="w-full px-2 py-1 border rounded"
+                                            placeholder="Aggregator name"
+                                        />
+                                    </td>
+                                    <td className="px-3 py-2">
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            value={item.commission_percent}
+                                            onChange={e => updateAggregator(item.id, 'commission_percent', e.target.value)}
+                                            className="w-full px-2 py-1 border rounded"
+                                            placeholder="Commission %"
+                                        />
+                                    </td>
+                                    <td className="px-3 py-2">
+                                        <label className="inline-flex items-center gap-2 text-sm text-gray-700">
+                                            <input
+                                                type="checkbox"
+                                                checked={item.active !== false}
+                                                onChange={e => updateAggregator(item.id, 'active', e.target.checked)}
+                                            />
+                                            Active
+                                        </label>
+                                    </td>
+                                </tr>
+                            ))}
+                            {aggregators.length === 0 && (
+                                <tr>
+                                    <td colSpan="3" className="text-center text-sm text-gray-500 px-3 py-4">No aggregators defined yet.</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add namespaced sheet helper and required tables for delivery aggregator and breakdown data
- expose delivery aggregator settings retrieval and saving endpoints
- provide management dashboard UI for editing delivery aggregator definitions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935454b7db0832597424a3ff2fad236)