### PR TITLE
Add inventory activity analytics for dashboard

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -2129,13 +2129,43 @@ function analyzeSalesData(salesData, targetDate, salesBreakdown) {
     return 0;
   }
 
+  function getAggregatorDetails() {
+    if (!salesBreakdown || !salesBreakdown.aggregator_details) return [];
+    try {
+      const parsed = typeof salesBreakdown.aggregator_details === 'string'
+        ? JSON.parse(salesBreakdown.aggregator_details)
+        : salesBreakdown.aggregator_details;
+      if (!Array.isArray(parsed)) return [];
+
+      return parsed
+        .map(item => ({
+          name: item.name || item.aggregator || `Aggregator ${item.id || ''}`.trim(),
+          amount: parseFloat(item.amount) || 0
+        }))
+        .filter(item => item.name || item.amount > 0);
+    } catch (error) {
+      Logger.log('Failed to parse aggregator details: ' + error.toString());
+      return [];
+    }
+  }
+
   const cash = getPaymentAmount(['cash_sales']);
   const card = getPaymentAmount(['card_sales']);
-  const delivery1 = getPaymentAmount(['delivery_aggregator_1', 'delivery_sales']);
-  const delivery2 = getPaymentAmount(['delivery_aggregator_2']);
-  const pettyCash = parseFloat(salesData.petty_cash_total) || 0;
+  const aggregatorDetails = getAggregatorDetails();
 
-  const paymentTotal = cash + card + delivery1 + delivery2;
+  const legacyAggregators = [
+    { name: 'Delivery Aggregator 1', amount: parseFloat(salesData.delivery_aggregator_1) || 0 },
+    { name: 'Delivery Aggregator 2', amount: parseFloat(salesData.delivery_aggregator_2) || 0 }
+  ].filter(item => item.amount > 0);
+
+  const deliveryDetails = aggregatorDetails.length ? aggregatorDetails : legacyAggregators;
+  const deliveryTotalFromDetails = deliveryDetails.reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
+  const deliveryTotal = deliveryTotalFromDetails > 0
+    ? deliveryTotalFromDetails
+    : getPaymentAmount(['delivery_sales']);
+
+  const pettyCash = parseFloat(salesData.petty_cash_total) || 0;
+  const paymentTotal = cash + card + deliveryTotal;
 
   analysis.payment_breakdown = {
     cash: {
@@ -2146,13 +2176,10 @@ function analyzeSalesData(salesData, targetDate, salesBreakdown) {
       amount: card,
       percentage: paymentTotal > 0 ? (card / paymentTotal * 100) : 0
     },
-    delivery_aggregator_1: {
-      amount: delivery1,
-      percentage: paymentTotal > 0 ? (delivery1 / paymentTotal * 100) : 0
-    },
-    delivery_aggregator_2: {
-      amount: delivery2,
-      percentage: paymentTotal > 0 ? (delivery2 / paymentTotal * 100) : 0
+    delivery_aggregators: {
+      amount: deliveryTotal,
+      percentage: paymentTotal > 0 ? (deliveryTotal / paymentTotal * 100) : 0,
+      details: deliveryDetails
     },
     total_breakdown: paymentTotal,
     variance_from_total: Math.abs(analysis.total_revenue - paymentTotal)
@@ -2208,8 +2235,10 @@ function analyzeSalesData(salesData, targetDate, salesBreakdown) {
 }
 
 function calculatePaymentDiversity(paymentBreakdown) {
-  const methods = ['cash', 'card', 'delivery_aggregator_1', 'delivery_aggregator_2'];
-  const percentages = methods.map(method => paymentBreakdown[method].percentage);
+  const methodKeys = Object.keys(paymentBreakdown || {}).filter(key => !['total_breakdown', 'variance_from_total'].includes(key));
+  if (methodKeys.length === 0) return 0;
+
+  const percentages = methodKeys.map(method => paymentBreakdown[method].percentage || 0);
 
   let entropy = 0;
   percentages.forEach(percentage => {
@@ -2219,7 +2248,8 @@ function calculatePaymentDiversity(paymentBreakdown) {
     }
   });
 
-  return Math.min(100, (entropy / Math.log2(methods.length)) * 100);
+  const base = Math.log2(Math.max(1, methodKeys.length));
+  return base === 0 ? 0 : Math.min(100, (entropy / base) * 100);
 }
 
 function calculateRevenueQualityScore(analysis) {

--- a/Code.gs
+++ b/Code.gs
@@ -1668,14 +1668,14 @@ function generateDashboardReport(date, options = {}) {
       dashboardData.enhanced_analytics.pettyCash = analyzePettyCashData(baseReport.pettyCashEntries, targetDate);
     }
 
-    if (config.includeInventoryAnalysis) {
-      dashboardData.enhanced_analytics.inventory = analyzeInventoryData(baseReport, targetDate);
-      dashboardData.enhanced_analytics.inventory_activity = generateInventoryActivity(targetDate);
-    }
+  if (config.includeInventoryAnalysis) {
+    dashboardData.enhanced_analytics.inventory = analyzeInventoryData(baseReport, targetDate);
+    dashboardData.enhanced_analytics.inventory_activity = generateInventoryActivity(targetDate);
+  }
 
-    if (baseReport.sales) {
-      dashboardData.enhanced_analytics.sales = analyzeSalesData(baseReport.sales, targetDate);
-    }
+  if (baseReport.sales) {
+    dashboardData.enhanced_analytics.sales = analyzeSalesData(baseReport.sales, targetDate, baseReport.salesBreakdown);
+  }
 
     if (config.compareToYesterday) {
       dashboardData.enhanced_analytics.comparisons = getComparativeData(targetDate, config);
@@ -2106,7 +2106,7 @@ function getItemUnitCost(category, itemName) {
   return 0;
 }
 
-function analyzeSalesData(salesData, targetDate) {
+function analyzeSalesData(salesData, targetDate, salesBreakdown) {
   const analysis = {
     total_revenue: parseFloat(salesData.total_revenue) || 0,
     shawarma_revenue: parseFloat(salesData.shawarma_revenue) || 0,
@@ -2116,10 +2116,23 @@ function analyzeSalesData(salesData, targetDate) {
     recommendations: []
   };
 
-  const cash = parseFloat(salesData.cash_sales) || 0;
-  const card = parseFloat(salesData.card_sales) || 0;
-  const delivery1 = parseFloat(salesData.delivery_aggregator_1) || 0;
-  const delivery2 = parseFloat(salesData.delivery_aggregator_2) || 0;
+  function getPaymentAmount(fields) {
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      if (salesData && salesData[field] !== undefined && salesData[field] !== '') {
+        return parseFloat(salesData[field]) || 0;
+      }
+      if (salesBreakdown && salesBreakdown[field] !== undefined && salesBreakdown[field] !== '') {
+        return parseFloat(salesBreakdown[field]) || 0;
+      }
+    }
+    return 0;
+  }
+
+  const cash = getPaymentAmount(['cash_sales']);
+  const card = getPaymentAmount(['card_sales']);
+  const delivery1 = getPaymentAmount(['delivery_aggregator_1', 'delivery_sales']);
+  const delivery2 = getPaymentAmount(['delivery_aggregator_2']);
   const pettyCash = parseFloat(salesData.petty_cash_total) || 0;
 
   const paymentTotal = cash + card + delivery1 + delivery2;

--- a/Code.gs
+++ b/Code.gs
@@ -1670,6 +1670,7 @@ function generateDashboardReport(date, options = {}) {
 
     if (config.includeInventoryAnalysis) {
       dashboardData.enhanced_analytics.inventory = analyzeInventoryData(baseReport, targetDate);
+      dashboardData.enhanced_analytics.inventory_activity = generateInventoryActivity(targetDate);
     }
 
     if (baseReport.sales) {
@@ -1765,6 +1766,141 @@ function analyzePettyCashData(pettyCashEntries, targetDate) {
   }
 
   return analysis;
+}
+
+function getSnapshotEntriesByDate(date) {
+  const snapshotData = getSheetData('SnapshotLog') || [];
+  const target = new Date(date).toDateString();
+  return snapshotData.filter(entry => entry.date && new Date(entry.date).toDateString() === target);
+}
+
+function aggregatePurchasesByItem(date) {
+  const purchases = getSheetData('PurchaseLog') || [];
+  const target = new Date(date).toDateString();
+  const totals = {};
+
+  purchases.forEach(p => {
+    if (p.delivery_date && new Date(p.delivery_date).toDateString() === target) {
+      if (!totals[p.item_id]) {
+        totals[p.item_id] = { quantity: 0, cost: 0 };
+      }
+      totals[p.item_id].quantity += Number(p.quantity) || 0;
+      totals[p.item_id].cost += Number(p.total_cost) || 0;
+    }
+  });
+
+  return totals;
+}
+
+function aggregateWasteByItem(date) {
+  const wasteEntries = getSheetData('WasteLog') || [];
+  const target = new Date(date).toDateString();
+  const totals = {};
+
+  wasteEntries.forEach(entry => {
+    if (entry.date && new Date(entry.date).toDateString() === target) {
+      if (!totals[entry.item_id]) {
+        totals[entry.item_id] = { quantity: 0, cost: 0 };
+      }
+      totals[entry.item_id].quantity += Number(entry.waste_quantity) || 0;
+      totals[entry.item_id].cost += Number(entry.estimated_cost || entry.cost_override) || 0;
+    }
+  });
+
+  return totals;
+}
+
+function generateInventoryActivity(date) {
+  const items = getSheetData('Item') || [];
+  const activeItems = items.filter(it => it.active !== false && it.active !== 'false');
+
+  const todaySnapshots = getSnapshotEntriesByDate(date);
+  const yesterday = new Date(date);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const previousSnapshots = getSnapshotEntriesByDate(yesterday);
+
+  const snapshotToMap = (entries) => {
+    return entries.reduce((acc, entry) => {
+      acc[entry.item_id] = Number(entry.closing_quantity) || 0;
+      return acc;
+    }, {});
+  };
+
+  const todaysMap = snapshotToMap(todaySnapshots);
+  const previousMap = snapshotToMap(previousSnapshots);
+  const purchases = aggregatePurchasesByItem(date);
+  const waste = aggregateWasteByItem(date);
+
+  const activity = [];
+  const summary = {
+    items_tracked: 0,
+    with_snapshots: 0,
+    missing_snapshots: 0,
+    total_received: 0,
+    total_waste: 0,
+    total_consumption: 0,
+    total_purchase_cost: 0,
+    total_waste_cost: 0
+  };
+
+  activeItems.forEach(item => {
+    const opening = previousMap[item.id] !== undefined ? previousMap[item.id] : null;
+    const closing = todaysMap[item.id] !== undefined ? todaysMap[item.id] : null;
+    const received = purchases[item.id] ? purchases[item.id].quantity : 0;
+    const wasted = waste[item.id] ? waste[item.id].quantity : 0;
+    const hasSnapshotData = opening !== null || closing !== null;
+
+    const calculatedUsage = (opening !== null && closing !== null)
+      ? (opening + received) - closing
+      : null;
+
+    const consumption = calculatedUsage !== null ? calculatedUsage - wasted : null;
+    const costPerUnit = Number(item.cost_per_unit) || 0;
+
+    const purchaseCost = purchases[item.id] ? purchases[item.id].cost : 0;
+    const wasteCost = waste[item.id] ? waste[item.id].cost : 0;
+    const consumptionCost = consumption !== null ? consumption * costPerUnit : null;
+
+    activity.push({
+      item_id: item.id,
+      item_name: item.name,
+      category: item.category,
+      unit: item.unit,
+      opening_quantity: opening,
+      received_quantity: received,
+      closing_quantity: closing,
+      waste_quantity: wasted,
+      calculated_usage: calculatedUsage,
+      consumption_quantity: consumption,
+      purchase_cost: purchaseCost,
+      waste_cost: wasteCost,
+      consumption_cost: consumptionCost,
+      data_status: hasSnapshotData ? 'ok' : 'missing_snapshot'
+    });
+
+    summary.items_tracked++;
+    if (hasSnapshotData) {
+      summary.with_snapshots++;
+    } else {
+      summary.missing_snapshots++;
+    }
+
+    summary.total_received += received;
+    summary.total_purchase_cost += purchaseCost;
+    summary.total_waste += wasted;
+    summary.total_waste_cost += wasteCost;
+
+    if (consumption !== null) {
+      summary.total_consumption += consumption;
+    }
+  });
+
+  return {
+    date: new Date(date),
+    generated_at: new Date(),
+    items: activity,
+    summary: summary
+  };
 }
 
 function analyzeInventoryData(reportData, targetDate) {

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1270,7 +1270,7 @@ function ManagementDashboard() {
                                 {dashboardData.enhanced_analytics && dashboardData.enhanced_analytics.sales && (
                                     <div>
                                         <h4 className="font-medium text-gray-700 mb-3">Payment Methods</h4>
-                                        <div className={`relative grid grid-cols-2 md:grid-cols-4 gap-3 text-sm ${showAggregatorDetails && hasDeliveryAggregatorDetails ? 'pb-28' : ''}`}>
+                                        <div className={`relative grid grid-cols-2 md:grid-cols-4 gap-3 text-sm ${showAggregatorDetails && hasDeliveryAggregatorDetails ? 'pb-48 md:pb-52' : ''}`}>
                                             {Object.entries(dashboardData.enhanced_analytics.sales.payment_breakdown).map(([method, data]) => {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
@@ -1305,7 +1305,7 @@ function ManagementDashboard() {
                                                             </div>
                                                             {showDetailsControl && showAggregatorDetails && (
                                                                 <div
-                                                                    className="absolute left-0 right-0 border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2"
+                                                                    className="absolute left-0 right-0 border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2 z-10"
                                                                     style={{ top: 'calc(100% + 0.75rem)' }}
                                                                 >
                                                                     <div className="flex items-center justify-between">

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1275,15 +1275,65 @@ function ManagementDashboard() {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
                                                 const isDeliveryAggregators = method === 'delivery_aggregators';
+
+                                                if (isDeliveryAggregators) {
+                                                    const showDetailsControl = data.details && data.details.length > 0;
+                                                    return (
+                                                        <div key={`${method}-block`} className="flex flex-col gap-2">
+                                                            <div className="h-full flex flex-col gap-2 border rounded p-2">
+                                                                <div className="flex items-center justify-between gap-2">
+                                                                    <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
+                                                                    <span className="font-medium">{data.amount.toFixed(2)}</span>
+                                                                </div>
+                                                                <div className="mt-1">
+                                                                    <div className="w-full bg-gray-200 rounded-full h-2">
+                                                                        <div className="bg-blue-600 h-2 rounded-full" style={{ width: `${Math.min(100, data.percentage)}%` }}></div>
+                                                                    </div>
+                                                                    <div className="flex items-center justify-between text-xs text-gray-500 mt-1">
+                                                                        <span>{data.percentage.toFixed(1)}%</span>
+                                                                        {showDetailsControl && (
+                                                                            <button
+                                                                                type="button"
+                                                                                className="text-blue-600 hover:text-blue-800 font-medium"
+                                                                                onClick={() => setShowAggregatorDetails(prev => !prev)}
+                                                                            >
+                                                                                {showAggregatorDetails ? 'Hide details' : 'View details'}
+                                                                            </button>
+                                                                        )}
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+
+                                                            {showDetailsControl && showAggregatorDetails && (
+                                                                <div className="border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2">
+                                                                    <div className="flex items-center justify-between">
+                                                                        <span className="text-sm font-medium text-gray-800">Aggregator breakdown</span>
+                                                                        <button
+                                                                            type="button"
+                                                                            className="text-xs text-blue-700 hover:text-blue-900"
+                                                                            onClick={() => setShowAggregatorDetails(false)}
+                                                                        >
+                                                                            Close
+                                                                        </button>
+                                                                    </div>
+                                                                    <div className="grid grid-cols-1 gap-2 text-sm text-gray-700">
+                                                                        {deliveryAggregatorDetails.map((agg, idx) => (
+                                                                            <div key={`${agg.name || 'agg'}-${idx}`} className="flex items-center justify-between">
+                                                                                <span className="truncate pr-2">{agg.name || `Aggregator ${idx + 1}`}</span>
+                                                                                <span className="font-medium">{(agg.amount || 0).toFixed(2)}</span>
+                                                                            </div>
+                                                                        ))}
+                                                                    </div>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    );
+                                                }
+
                                                 return (
                                                     <div key={method} className="border rounded p-2 h-full flex flex-col gap-2">
                                                         <div className="flex items-center justify-between gap-2">
-                                                            <div className="flex items-center gap-2">
-                                                                <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
-                                                                {isDeliveryAggregators && data.details && data.details.length > 0 && (
-                                                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] bg-blue-100 text-blue-700">Details</span>
-                                                                )}
-                                                            </div>
+                                                            <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
                                                             <span className="font-medium">{data.amount.toFixed(2)}</span>
                                                         </div>
                                                         <div className="mt-1">
@@ -1296,37 +1346,6 @@ function ManagementDashboard() {
                                                 );
                                             }).filter(Boolean)}
                                         </div>
-
-                                        {hasDeliveryAggregatorDetails && (
-                                            <div className="mt-4 bg-white border rounded-lg shadow-sm p-4">
-                                                <div className="flex items-center justify-between mb-2">
-                                                    <div className="flex items-center gap-2">
-                                                        <span className="text-sm font-medium text-gray-800">Delivery aggregator breakdown</span>
-                                                        <span className="text-xs text-gray-500">Supplemental detail</span>
-                                                    </div>
-                                                    <button
-                                                        type="button"
-                                                        className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
-                                                        onClick={() => setShowAggregatorDetails(prev => !prev)}
-                                                    >
-                                                        <span>{showAggregatorDetails ? 'Hide' : 'View'} breakdown</span>
-                                                        <span aria-hidden="true">{showAggregatorDetails ? '▴' : '▾'}</span>
-                                                    </button>
-                                                </div>
-                                                {showAggregatorDetails && (
-                                                    <div className="border rounded-md bg-gray-50 p-3">
-                                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                                                            {deliveryAggregatorDetails.map((agg, idx) => (
-                                                                <div key={`${agg.name || 'agg'}-${idx}`} className="flex items-center justify-between text-sm text-gray-700">
-                                                                    <span className="truncate pr-2">{agg.name || `Aggregator ${idx + 1}`}</span>
-                                                                    <span className="font-medium">{(agg.amount || 0).toFixed(2)}</span>
-                                                                </div>
-                                                            ))}
-                                                        </div>
-                                                    </div>
-                                                )}
-                                            </div>
-                                        )}
 
                                         {dashboardData.enhanced_analytics.sales.payment_breakdown.variance_from_total > 0 && (
                                             <div className={`mt-3 p-2 rounded text-sm ${

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -306,6 +306,43 @@ function ManagementDashboard() {
             });
         }
 
+        if (analytics.inventory_activity) {
+            const summary = analytics.inventory_activity.summary || {};
+            processed.inventory_activity = {
+                received: summary.total_received || 0,
+                consumption: summary.total_consumption || 0,
+                waste: summary.total_waste || 0,
+                purchase_cost: summary.total_purchase_cost || 0,
+                waste_cost: summary.total_waste_cost || 0,
+                missing_snapshots: summary.missing_snapshots || 0
+            };
+
+            const movements = (analytics.inventory_activity.items || [])
+                .filter(item => item.data_status === 'ok' && item.consumption_quantity !== null)
+                .sort((a, b) => (b.consumption_quantity || 0) - (a.consumption_quantity || 0))
+                .slice(0, 3);
+
+            if (movements.length) {
+                processed.inventory_movements = movements;
+            }
+
+            if (processed.inventory_activity.missing_snapshots > 0) {
+                processed.alerts.push({
+                    type: 'warning',
+                    source: 'inventory',
+                    message: `${processed.inventory_activity.missing_snapshots} items missing snapshot data`
+                });
+            }
+
+            if (processed.inventory_activity.waste_cost > 100) {
+                processed.alerts.push({
+                    type: 'danger',
+                    source: 'inventory',
+                    message: 'Waste cost is trending high today'
+                });
+            }
+        }
+
         if (analytics.sales) {
             processed.sales_summary = {
                 quality_score: analytics.sales.performance_metrics.revenue_quality_score,
@@ -1406,6 +1443,63 @@ function ManagementDashboard() {
                                 <div className="bg-green-50 p-4 rounded-lg text-center">
                                     <h4 className="font-medium text-green-800 text-sm">Total Value</h4>
                                     <p className="text-lg font-bold text-green-600">{dashboardData.processed_analytics.inventory_summary.total_value.toFixed(0)} QAR</p>
+                                </div>
+                            </div>
+                        )}
+
+                        {dashboardData && dashboardData.processed_analytics && dashboardData.processed_analytics.inventory_activity && (
+                            <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
+                                <div className="bg-indigo-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-indigo-800 text-sm">Received Today</h4>
+                                    <p className="text-xl font-bold text-indigo-700">{dashboardData.processed_analytics.inventory_activity.received.toFixed(2)}</p>
+                                </div>
+                                <div className="bg-emerald-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-emerald-800 text-sm">Consumption</h4>
+                                    <p className="text-xl font-bold text-emerald-700">{dashboardData.processed_analytics.inventory_activity.consumption.toFixed(2)}</p>
+                                </div>
+                                <div className="bg-orange-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-orange-800 text-sm">Waste</h4>
+                                    <p className="text-xl font-bold text-orange-700">{dashboardData.processed_analytics.inventory_activity.waste.toFixed(2)}</p>
+                                </div>
+                                <div className="bg-blue-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-blue-800 text-sm">Purchase Cost</h4>
+                                    <p className="text-lg font-bold text-blue-700">{dashboardData.processed_analytics.inventory_activity.purchase_cost.toFixed(2)} QAR</p>
+                                </div>
+                                <div className="bg-amber-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-amber-800 text-sm">Waste Cost</h4>
+                                    <p className="text-lg font-bold text-amber-700">{dashboardData.processed_analytics.inventory_activity.waste_cost.toFixed(2)} QAR</p>
+                                </div>
+                                <div className="bg-gray-50 p-4 rounded-lg text-center">
+                                    <h4 className="font-medium text-gray-800 text-sm">Missing Snapshots</h4>
+                                    <p className={`text-xl font-bold ${dashboardData.processed_analytics.inventory_activity.missing_snapshots > 0 ? 'text-red-600' : 'text-gray-600'}`}>{dashboardData.processed_analytics.inventory_activity.missing_snapshots}</p>
+                                </div>
+                            </div>
+                        )}
+
+                        {dashboardData && dashboardData.processed_analytics && dashboardData.processed_analytics.inventory_movements && (
+                            <div className="bg-gray-50 rounded-lg p-4 border">
+                                <div className="flex items-center justify-between mb-3">
+                                    <h4 className="font-medium text-gray-800">Top Movements</h4>
+                                    <span className="text-xs text-gray-500">Consumption vs waste</span>
+                                </div>
+                                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                                    {dashboardData.processed_analytics.inventory_movements.map(item => (
+                                        <div key={item.item_id} className="bg-white shadow-sm rounded-lg p-3 border">
+                                            <div className="flex items-center justify-between mb-1">
+                                                <div>
+                                                    <p className="text-sm font-semibold text-gray-800">{item.item_name}</p>
+                                                    <p className="text-xs text-gray-500">{item.category}</p>
+                                                </div>
+                                                <span className="text-xs px-2 py-1 rounded-full bg-blue-50 text-blue-700">{item.unit}</span>
+                                            </div>
+                                            <div className="text-xs text-gray-600 space-y-1">
+                                                <div className="flex justify-between"><span>Opening</span><span className="font-medium text-gray-800">{item.opening_quantity != null ? item.opening_quantity.toFixed(2) : '—'}</span></div>
+                                                <div className="flex justify-between"><span>Received</span><span className="font-medium text-indigo-700">{item.received_quantity.toFixed(2)}</span></div>
+                                                <div className="flex justify-between"><span>Consumption</span><span className="font-medium text-emerald-700">{item.consumption_quantity != null ? item.consumption_quantity.toFixed(2) : '—'}</span></div>
+                                                <div className="flex justify-between"><span>Waste</span><span className="font-medium text-orange-700">{item.waste_quantity.toFixed(2)}</span></div>
+                                            </div>
+                                        </div>
+                                    ))}
                                 </div>
                             </div>
                         )}

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1270,7 +1270,7 @@ function ManagementDashboard() {
                                 {dashboardData.enhanced_analytics && dashboardData.enhanced_analytics.sales && (
                                     <div>
                                         <h4 className="font-medium text-gray-700 mb-3">Payment Methods</h4>
-                                        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+                                        <div className={`relative grid grid-cols-2 md:grid-cols-4 gap-3 text-sm ${showAggregatorDetails && hasDeliveryAggregatorDetails ? 'pb-28' : ''}`}>
                                             {Object.entries(dashboardData.enhanced_analytics.sales.payment_breakdown).map(([method, data]) => {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
@@ -1279,8 +1279,8 @@ function ManagementDashboard() {
                                                 if (isDeliveryAggregators) {
                                                     const showDetailsControl = data.details && data.details.length > 0;
                                                     return (
-                                                        <div key={`${method}-block`} className="flex flex-col gap-2">
-                                                            <div className="h-full flex flex-col gap-2 border rounded p-2">
+                                                        <div key={`${method}-block`} className="relative flex flex-col gap-2">
+                                                            <div className="h-full flex flex-col gap-2 border rounded p-2 bg-white">
                                                                 <div className="flex items-center justify-between gap-2">
                                                                     <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
                                                                     <span className="font-medium">{data.amount.toFixed(2)}</span>
@@ -1303,9 +1303,11 @@ function ManagementDashboard() {
                                                                     </div>
                                                                 </div>
                                                             </div>
-
                                                             {showDetailsControl && showAggregatorDetails && (
-                                                                <div className="border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2">
+                                                                <div
+                                                                    className="absolute left-0 right-0 border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2"
+                                                                    style={{ top: 'calc(100% + 0.75rem)' }}
+                                                                >
                                                                     <div className="flex items-center justify-between">
                                                                         <span className="text-sm font-medium text-gray-800">Aggregator breakdown</span>
                                                                         <button

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -19,6 +19,8 @@ function ManagementDashboard() {
     const [aggregators, setAggregators] = React.useState([]);
     const [aggregatorSaving, setAggregatorSaving] = React.useState(false);
     const [showAggregatorDetails, setShowAggregatorDetails] = React.useState(false);
+    const aggregatorDetailsRef = React.useRef(null);
+    const [aggregatorDetailsHeight, setAggregatorDetailsHeight] = React.useState(0);
 
     const deliveryAggregatorDetails = dashboardData &&
         dashboardData.enhanced_analytics &&
@@ -28,6 +30,14 @@ function ManagementDashboard() {
         dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators.details;
 
     const hasDeliveryAggregatorDetails = deliveryAggregatorDetails && deliveryAggregatorDetails.length > 0;
+
+    React.useEffect(() => {
+        if (showAggregatorDetails && aggregatorDetailsRef.current) {
+            setAggregatorDetailsHeight(aggregatorDetailsRef.current.offsetHeight);
+        } else {
+            setAggregatorDetailsHeight(0);
+        }
+    }, [showAggregatorDetails, deliveryAggregatorDetails]);
 
     React.useEffect(() => {
         if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
@@ -1270,7 +1280,10 @@ function ManagementDashboard() {
                                 {dashboardData.enhanced_analytics && dashboardData.enhanced_analytics.sales && (
                                     <div>
                                         <h4 className="font-medium text-gray-700 mb-3">Payment Methods</h4>
-                                        <div className={`relative grid grid-cols-2 md:grid-cols-4 gap-3 text-sm ${showAggregatorDetails && hasDeliveryAggregatorDetails ? 'pb-48 md:pb-52' : ''}`}>
+                                        <div
+                                            className="relative grid grid-cols-2 md:grid-cols-4 gap-3 text-sm"
+                                            style={showAggregatorDetails && hasDeliveryAggregatorDetails ? { paddingBottom: `${aggregatorDetailsHeight + 16}px` } : undefined}
+                                        >
                                             {Object.entries(dashboardData.enhanced_analytics.sales.payment_breakdown).map(([method, data]) => {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
@@ -1307,6 +1320,7 @@ function ManagementDashboard() {
                                                                 <div
                                                                     className="absolute left-0 right-0 border border-blue-200 rounded-md bg-blue-50 p-3 shadow-inner flex flex-col gap-2 z-10"
                                                                     style={{ top: 'calc(100% + 0.75rem)' }}
+                                                                    ref={aggregatorDetailsRef}
                                                                 >
                                                                     <div className="flex items-center justify-between">
                                                                         <span className="text-sm font-medium text-gray-800">Aggregator breakdown</span>

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1263,7 +1263,7 @@ function ManagementDashboard() {
                                         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
                                             {Object.entries(dashboardData.enhanced_analytics.sales.payment_breakdown).map(([method, data]) => {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
-                                                const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregator_1: 'Delivery 1', delivery_aggregator_2: 'Delivery 2' };
+                                                const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
                                                 return (
                                                     <div key={method} className="border rounded p-2">
                                                         <div className="flex justify-between items-center">
@@ -1276,6 +1276,16 @@ function ManagementDashboard() {
                                                             </div>
                                                             <span className="text-xs text-gray-500">{data.percentage.toFixed(1)}%</span>
                                                         </div>
+                                                        {method === 'delivery_aggregators' && data.details && data.details.length > 0 && (
+                                                            <div className="mt-2 space-y-1">
+                                                                {data.details.map((agg, idx) => (
+                                                                    <div key={`${agg.name || 'agg'}-${idx}`} className="flex justify-between text-xs text-gray-600">
+                                                                        <span>{agg.name || `Aggregator ${idx + 1}`}</span>
+                                                                        <span>{(agg.amount || 0).toFixed(2)}</span>
+                                                                    </div>
+                                                                ))}
+                                                            </div>
+                                                        )}
                                                     </div>
                                                 );
                                             }).filter(Boolean)}

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -20,6 +20,15 @@ function ManagementDashboard() {
     const [aggregatorSaving, setAggregatorSaving] = React.useState(false);
     const [showAggregatorDetails, setShowAggregatorDetails] = React.useState(false);
 
+    const deliveryAggregatorDetails = dashboardData &&
+        dashboardData.enhanced_analytics &&
+        dashboardData.enhanced_analytics.sales &&
+        dashboardData.enhanced_analytics.sales.payment_breakdown &&
+        dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators &&
+        dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators.details;
+
+    const hasDeliveryAggregatorDetails = deliveryAggregatorDetails && deliveryAggregatorDetails.length > 0;
+
     React.useEffect(() => {
         if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
             loadDashboardData();
@@ -1288,7 +1297,7 @@ function ManagementDashboard() {
                                             }).filter(Boolean)}
                                         </div>
 
-                                        {dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators?.details?.length > 0 && (
+                                        {hasDeliveryAggregatorDetails && (
                                             <div className="mt-4 bg-white border rounded-lg shadow-sm p-4">
                                                 <div className="flex items-center justify-between mb-2">
                                                     <div className="flex items-center gap-2">
@@ -1307,7 +1316,7 @@ function ManagementDashboard() {
                                                 {showAggregatorDetails && (
                                                     <div className="border rounded-md bg-gray-50 p-3">
                                                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                                                            {dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators.details.map((agg, idx) => (
+                                                            {deliveryAggregatorDetails.map((agg, idx) => (
                                                                 <div key={`${agg.name || 'agg'}-${idx}`} className="flex items-center justify-between text-sm text-gray-700">
                                                                     <span className="truncate pr-2">{agg.name || `Aggregator ${idx + 1}`}</span>
                                                                     <span className="font-medium">{(agg.amount || 0).toFixed(2)}</span>

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -18,6 +18,7 @@ function ManagementDashboard() {
     const [showDebugData, setShowDebugData] = React.useState(false);
     const [aggregators, setAggregators] = React.useState([]);
     const [aggregatorSaving, setAggregatorSaving] = React.useState(false);
+    const [showAggregatorDetails, setShowAggregatorDetails] = React.useState(false);
 
     React.useEffect(() => {
         if (selectedPeriod !== 'custom' || (selectedPeriod === 'custom' && customDate)) {
@@ -1264,6 +1265,7 @@ function ManagementDashboard() {
                                             {Object.entries(dashboardData.enhanced_analytics.sales.payment_breakdown).map(([method, data]) => {
                                                 if (method === 'total_breakdown' || method === 'variance_from_total') return null;
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
+                                                const isDeliveryAggregators = method === 'delivery_aggregators';
                                                 return (
                                                     <div key={method} className="border rounded p-2">
                                                         <div className="flex justify-between items-center">
@@ -1276,14 +1278,26 @@ function ManagementDashboard() {
                                                             </div>
                                                             <span className="text-xs text-gray-500">{data.percentage.toFixed(1)}%</span>
                                                         </div>
-                                                        {method === 'delivery_aggregators' && data.details && data.details.length > 0 && (
-                                                            <div className="mt-2 space-y-1">
-                                                                {data.details.map((agg, idx) => (
-                                                                    <div key={`${agg.name || 'agg'}-${idx}`} className="flex justify-between text-xs text-gray-600">
-                                                                        <span>{agg.name || `Aggregator ${idx + 1}`}</span>
-                                                                        <span>{(agg.amount || 0).toFixed(2)}</span>
+                                                        {isDeliveryAggregators && data.details && data.details.length > 0 && (
+                                                            <div className="mt-2">
+                                                                <button
+                                                                    type="button"
+                                                                    className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                                                                    onClick={() => setShowAggregatorDetails(prev => !prev)}
+                                                                >
+                                                                    <span>{showAggregatorDetails ? 'Hide details' : 'View aggregator breakdown'}</span>
+                                                                    <span aria-hidden="true">{showAggregatorDetails ? '▴' : '▾'}</span>
+                                                                </button>
+                                                                {showAggregatorDetails && (
+                                                                    <div className="mt-2 space-y-1 border-t pt-2">
+                                                                        {data.details.map((agg, idx) => (
+                                                                            <div key={`${agg.name || 'agg'}-${idx}`} className="flex justify-between text-xs text-gray-600">
+                                                                                <span>{agg.name || `Aggregator ${idx + 1}`}</span>
+                                                                                <span>{(agg.amount || 0).toFixed(2)}</span>
+                                                                            </div>
+                                                                        ))}
                                                                     </div>
-                                                                ))}
+                                                                )}
                                                             </div>
                                                         )}
                                                     </div>

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1267,9 +1267,14 @@ function ManagementDashboard() {
                                                 const methodNames = { cash: 'Cash', card: 'Card', delivery_aggregators: 'Delivery Aggregators' };
                                                 const isDeliveryAggregators = method === 'delivery_aggregators';
                                                 return (
-                                                    <div key={method} className="border rounded p-2">
-                                                        <div className="flex justify-between items-center">
-                                                            <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
+                                                    <div key={method} className="border rounded p-2 h-full flex flex-col gap-2">
+                                                        <div className="flex items-center justify-between gap-2">
+                                                            <div className="flex items-center gap-2">
+                                                                <span className="text-gray-600 text-xs">{methodNames[method] || method}</span>
+                                                                {isDeliveryAggregators && data.details && data.details.length > 0 && (
+                                                                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] bg-blue-100 text-blue-700">Details</span>
+                                                                )}
+                                                            </div>
                                                             <span className="font-medium">{data.amount.toFixed(2)}</span>
                                                         </div>
                                                         <div className="mt-1">
@@ -1278,19 +1283,16 @@ function ManagementDashboard() {
                                                             </div>
                                                             <span className="text-xs text-gray-500">{data.percentage.toFixed(1)}%</span>
                                                         </div>
-                                                        {isDeliveryAggregators && data.details && data.details.length > 0 && (
-                                                            <p className="mt-2 text-[11px] text-gray-500">Detailed breakdown available below</p>
-                                                        )}
                                                     </div>
                                                 );
                                             }).filter(Boolean)}
                                         </div>
 
                                         {dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators?.details?.length > 0 && (
-                                            <div className="mt-3">
+                                            <div className="mt-4 bg-white border rounded-lg shadow-sm p-4">
                                                 <div className="flex items-center justify-between mb-2">
                                                     <div className="flex items-center gap-2">
-                                                        <span className="text-sm font-medium text-gray-700">Delivery aggregator breakdown</span>
+                                                        <span className="text-sm font-medium text-gray-800">Delivery aggregator breakdown</span>
                                                         <span className="text-xs text-gray-500">Supplemental detail</span>
                                                     </div>
                                                     <button

--- a/ManagementDashboard.html
+++ b/ManagementDashboard.html
@@ -1279,31 +1279,43 @@ function ManagementDashboard() {
                                                             <span className="text-xs text-gray-500">{data.percentage.toFixed(1)}%</span>
                                                         </div>
                                                         {isDeliveryAggregators && data.details && data.details.length > 0 && (
-                                                            <div className="mt-2">
-                                                                <button
-                                                                    type="button"
-                                                                    className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
-                                                                    onClick={() => setShowAggregatorDetails(prev => !prev)}
-                                                                >
-                                                                    <span>{showAggregatorDetails ? 'Hide details' : 'View aggregator breakdown'}</span>
-                                                                    <span aria-hidden="true">{showAggregatorDetails ? '▴' : '▾'}</span>
-                                                                </button>
-                                                                {showAggregatorDetails && (
-                                                                    <div className="mt-2 space-y-1 border-t pt-2">
-                                                                        {data.details.map((agg, idx) => (
-                                                                            <div key={`${agg.name || 'agg'}-${idx}`} className="flex justify-between text-xs text-gray-600">
-                                                                                <span>{agg.name || `Aggregator ${idx + 1}`}</span>
-                                                                                <span>{(agg.amount || 0).toFixed(2)}</span>
-                                                                            </div>
-                                                                        ))}
-                                                                    </div>
-                                                                )}
-                                                            </div>
+                                                            <p className="mt-2 text-[11px] text-gray-500">Detailed breakdown available below</p>
                                                         )}
                                                     </div>
                                                 );
                                             }).filter(Boolean)}
                                         </div>
+
+                                        {dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators?.details?.length > 0 && (
+                                            <div className="mt-3">
+                                                <div className="flex items-center justify-between mb-2">
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="text-sm font-medium text-gray-700">Delivery aggregator breakdown</span>
+                                                        <span className="text-xs text-gray-500">Supplemental detail</span>
+                                                    </div>
+                                                    <button
+                                                        type="button"
+                                                        className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
+                                                        onClick={() => setShowAggregatorDetails(prev => !prev)}
+                                                    >
+                                                        <span>{showAggregatorDetails ? 'Hide' : 'View'} breakdown</span>
+                                                        <span aria-hidden="true">{showAggregatorDetails ? '▴' : '▾'}</span>
+                                                    </button>
+                                                </div>
+                                                {showAggregatorDetails && (
+                                                    <div className="border rounded-md bg-gray-50 p-3">
+                                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                                            {dashboardData.enhanced_analytics.sales.payment_breakdown.delivery_aggregators.details.map((agg, idx) => (
+                                                                <div key={`${agg.name || 'agg'}-${idx}`} className="flex items-center justify-between text-sm text-gray-700">
+                                                                    <span className="truncate pr-2">{agg.name || `Aggregator ${idx + 1}`}</span>
+                                                                    <span className="font-medium">{(agg.amount || 0).toFixed(2)}</span>
+                                                                </div>
+                                                            ))}
+                                                        </div>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
 
                                         {dashboardData.enhanced_analytics.sales.payment_breakdown.variance_from_total > 0 && (
                                             <div className={`mt-3 p-2 rounded text-sm ${


### PR DESCRIPTION
## Summary
- add inventory activity aggregation combining snapshots, purchases, and waste into the dashboard report
- surface inventory movement summaries and top item movements in the management dashboard
- enrich processed analytics with inventory activity alerts and cost visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693962388ff48325b390f57e30b0cf8c)