### PR TITLE
Add purchases and waste management UI components

### DIFF
--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -50,6 +50,11 @@ function WasteTodayModal({ items, onClose, onSave }) {
     const emptyRow = { item: '', quantity: '', reason: 'Spoiled' };
     const [rows, setRows] = React.useState([ { ...emptyRow } ]);
 
+    const resolveUnit = (itemKey) => {
+        const match = items.find(it => (it.id || it.name) === itemKey);
+        return match && match.unit ? match.unit : '';
+    };
+
     const updateRow = (index, key, value) => {
         setRows(prev => prev.map((row, i) => i === index ? { ...row, [key]: value } : row));
     };
@@ -63,7 +68,7 @@ function WasteTodayModal({ items, onClose, onSave }) {
             alert('Please select an item and quantity for each waste entry.');
             return;
         }
-        onSave(rows.map(r => ({ ...r, unit: (items.find(it => (it.id || it.name) === r.item)?.unit) || '' })));
+        onSave(rows.map(r => ({ ...r, unit: resolveUnit(r.item) })));
     };
 
     return React.createElement('div', { className: 'fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50' },
@@ -98,7 +103,7 @@ function WasteTodayModal({ items, onClose, onSave }) {
                         React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Unit'),
                         React.createElement('input', {
                             type: 'text',
-                            value: (items.find(it => (it.id || it.name) === row.item)?.unit) || 'auto-filled',
+                            value: resolveUnit(row.item) || 'auto-filled',
                             readOnly: true,
                             className: 'w-full p-2 border rounded bg-gray-100'
                         })

--- a/DailyEntryTab.html
+++ b/DailyEntryTab.html
@@ -46,6 +46,86 @@ function getCurrentEmployeeSession() {
     return window.currentEmployeeSession;
 }
 
+function WasteTodayModal({ items, onClose, onSave }) {
+    const emptyRow = { item: '', quantity: '', reason: 'Spoiled' };
+    const [rows, setRows] = React.useState([ { ...emptyRow } ]);
+
+    const updateRow = (index, key, value) => {
+        setRows(prev => prev.map((row, i) => i === index ? { ...row, [key]: value } : row));
+    };
+
+    const addRow = () => setRows(prev => [...prev, { ...emptyRow }]);
+    const removeRow = (index) => setRows(prev => prev.filter((_, i) => i !== index));
+
+    const handleSave = () => {
+        const hasMissing = rows.some(r => !r.item || !r.quantity);
+        if (hasMissing) {
+            alert('Please select an item and quantity for each waste entry.');
+            return;
+        }
+        onSave(rows.map(r => ({ ...r, unit: (items.find(it => (it.id || it.name) === r.item)?.unit) || '' })));
+    };
+
+    return React.createElement('div', { className: 'fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50' },
+        React.createElement('div', { className: 'bg-white rounded-lg shadow-xl w-full max-w-3xl p-6 space-y-4' },
+            React.createElement('div', { className: 'flex justify-between items-center' },
+                React.createElement('h3', { className: 'text-lg font-semibold' }, 'Log Waste for Today'),
+                React.createElement('button', { onClick: onClose, className: 'text-gray-500' }, '✕')
+            ),
+            React.createElement('div', { className: 'space-y-3 max-h-[60vh] overflow-y-auto' },
+                rows.map((row, idx) => React.createElement('div', { key: idx, className: 'grid grid-cols-1 md:grid-cols-4 gap-3 items-end border rounded p-3' },
+                    React.createElement('div', null,
+                        React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Item'),
+                        React.createElement('select', {
+                            value: row.item,
+                            onChange: e => updateRow(idx, 'item', e.target.value),
+                            className: 'w-full p-2 border rounded'
+                        },
+                            [React.createElement('option', { key: '', value: '' }, 'Select Item')].concat(items.map(it => React.createElement('option', { key: it.id || it.name, value: it.id || it.name }, it.name || it.id)))
+                        )
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Quantity'),
+                        React.createElement('input', {
+                            type: 'number',
+                            step: '0.01',
+                            value: row.quantity,
+                            onChange: e => updateRow(idx, 'quantity', normalizeNumberInput(e.target.value)),
+                            className: 'w-full p-2 border rounded'
+                        })
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Unit'),
+                        React.createElement('input', {
+                            type: 'text',
+                            value: (items.find(it => (it.id || it.name) === row.item)?.unit) || 'auto-filled',
+                            readOnly: true,
+                            className: 'w-full p-2 border rounded bg-gray-100'
+                        })
+                    ),
+                    React.createElement('div', { className: 'flex gap-2 items-center' },
+                        React.createElement('select', {
+                            value: row.reason,
+                            onChange: e => updateRow(idx, 'reason', e.target.value),
+                            className: 'p-2 border rounded w-full'
+                        },
+                            ['Spoiled', 'Prep Error', 'Expired', 'Damaged', 'Other'].map(reason => React.createElement('option', { key: reason, value: reason }, reason))
+                        ),
+                        rows.length > 1 && React.createElement('button', { className: 'text-red-600 text-lg px-2', onClick: () => removeRow(idx) }, '✕')
+                    )
+                ))
+            ),
+            React.createElement('div', { className: 'flex justify-between items-center' },
+                React.createElement('button', { className: 'px-3 py-2 text-sm border rounded', onClick: addRow }, 'Add Row'),
+                React.createElement('div', { className: 'flex gap-2' },
+                    React.createElement('button', { className: 'px-4 py-2 rounded border', onClick: onClose }, 'Cancel'),
+                    React.createElement('button', { className: 'px-4 py-2 rounded bg-redbrand-600 text-white', onClick: handleSave }, 'Save Waste Entries')
+                )
+            )
+        )
+    );
+}
+
 function initializeEmployeeContext() {
     const session = getCurrentEmployeeSession();
     if (session && session.employee_id && session.employee_id !== 'management') {
@@ -433,6 +513,8 @@ function DailyEntryTab() {
         paid_by: ''
     });
     const [editingEntryIndex, setEditingEntryIndex] = React.useState(-1);
+    const [wasteEntries, setWasteEntries] = React.useState([]);
+    const [showWasteModal, setShowWasteModal] = React.useState(false);
 
     const validateTranslations = () => {
         const requiredKeys = [
@@ -582,6 +664,14 @@ function DailyEntryTab() {
             ]
         }
     };
+
+    const wasteItemOptions = (state && state.data && state.data.ingredients && state.data.ingredients.length > 0)
+        ? state.data.ingredients.map(item => ({ id: item.id || item.name, name: item.name || item.id, unit: item.unit || '' }))
+        : [
+            { id: 'shawarma', name: 'Shawarma', unit: 'kg' },
+            { id: 'pita', name: 'Pita Bread', unit: 'pcs' },
+            { id: 'lettuce', name: 'Lettuce', unit: 'kg' }
+        ];
 
     const PETTY_CASH_CATEGORIES = [
         { key: 'fuel', label: 'Fuel' },
@@ -1290,6 +1380,11 @@ function DailyEntryTab() {
 
     const calculateDeliveryTotal = () => {
         return (paymentBreakdown.delivery_aggregators || []).reduce((sum, item) => sum + (parseFloat(item.amount) || 0), 0);
+    };
+
+    const handleWasteSave = (entries) => {
+        setWasteEntries(prev => [...prev, ...entries]);
+        setShowWasteModal(false);
     };
 
     const handleAddPettyCashEntry = () => {
@@ -2120,7 +2215,42 @@ function DailyEntryTab() {
                         )
                     )
                 ),
-                
+
+                React.createElement('div', { className: 'border border-gray-200 rounded-lg p-6 space-y-3' },
+                    React.createElement('div', { className: 'flex items-center justify-between' },
+                        React.createElement('h3', { className: 'text-lg font-semibold text-gray-800' }, 'Waste Tracking'),
+                        React.createElement('button', {
+                            type: 'button',
+                            className: 'bg-redbrand-600 text-white px-4 py-2 rounded',
+                            onClick: () => setShowWasteModal(true),
+                            disabled: fieldsLocked
+                        }, '➕ Add Waste')
+                    ),
+                    React.createElement('p', { className: 'text-sm text-gray-600' }, `${wasteEntries.length} waste entries logged today`),
+                    wasteEntries.length > 0 && React.createElement('div', { className: 'overflow-x-auto' },
+                        React.createElement('table', { className: 'w-full text-sm border' },
+                            React.createElement('thead', { className: 'bg-gray-50' },
+                                React.createElement('tr', null,
+                                    ['Item', 'Qty', 'Reason'].map(header => React.createElement('th', { key: header, className: 'p-2 text-left border' }, header))
+                                )
+                            ),
+                            React.createElement('tbody', null,
+                                wasteEntries.map((entry, idx) => React.createElement('tr', { key: idx, className: 'border-b' },
+                                    React.createElement('td', { className: 'p-2 border' }, entry.item),
+                                    React.createElement('td', { className: 'p-2 border' }, `${entry.quantity} ${entry.unit || ''}`),
+                                    React.createElement('td', { className: 'p-2 border' }, entry.reason)
+                                ))
+                            )
+                        )
+                    )
+                ),
+
+                showWasteModal && React.createElement(WasteTodayModal, {
+                    items: wasteItemOptions,
+                    onClose: () => setShowWasteModal(false),
+                    onSave: handleWasteSave
+                }),
+
                 // Notes Section
                 React.createElement('div', {
                     className: 'border border-gray-200 rounded-lg p-6'

--- a/index.html
+++ b/index.html
@@ -1492,10 +1492,13 @@ function DailyEntryTab({ employeeSession }) {
                 .sort((a, b) => new Date(b.date) - new Date(a.date));
 
             const handleSave = (entry) => {
+                const resolvedUnit = entry.unit || (items.find(it => (it.id || it.name) === entry.item) || {}).unit || '';
+                const payload = { ...entry, unit: resolvedUnit, variance: (parseFloat(entry.quantity || 0) > 5) };
+
                 if (editing) {
-                    setEntries(prev => prev.map(e => e.id === editing.id ? { ...entry, id: editing.id, unit: entry.unit || editing.unit, variance: (parseFloat(entry.quantity || 0) > 5) } : e));
+                    setEntries(prev => prev.map(e => e.id === editing.id ? { ...payload, id: editing.id } : e));
                 } else {
-                    setEntries(prev => [{ ...entry, id: Date.now(), unit: entry.unit || (items.find(it => (it.id || it.name) === entry.item)?.unit || ''), variance: (parseFloat(entry.quantity || 0) > 5) }, ...prev]);
+                    setEntries(prev => [{ ...payload, id: Date.now() }, ...prev]);
                 }
                 setEditing(null);
                 setShowModal(false);

--- a/index.html
+++ b/index.html
@@ -984,6 +984,8 @@
                             { id: 'menu', label: t('menu'), icon: '📋' },
                             { id: 'ingredients', label: t('ingredients'), icon: '🥬' },
                             { id: 'inventory', label: t('inventory'), icon: '📦' },
+                            { id: 'purchases', label: 'Purchases', icon: '💳' },
+                            { id: 'waste_log', label: 'Waste Log', icon: '🗑️' },
                             { id: 'suppliers', label: t('suppliers'), icon: '🚛' },
                             { id: 'employees', label: t('employees'), icon: '👥' },
                             { id: 'reports', label: t('reports'), icon: '📈' }
@@ -1159,6 +1161,421 @@ function DailyEntryTab({ employeeSession }) {
                 React.createElement('p', {
                     className: 'text-gray-600'
                 }, 'Ingredients management coming soon...')
+            );
+        }
+
+        function PurchaseFormModal({ items, suppliers, onClose, onSave }) {
+            const [form, setForm] = React.useState({
+                item: '',
+                brand: '',
+                quantity: '',
+                unitCost: '',
+                supplier: '',
+                invoice: '',
+                date: new Date().toISOString().split('T')[0]
+            });
+
+            const updateField = (key, value) => setForm(prev => ({ ...prev, [key]: value }));
+
+            const handleSubmit = () => {
+                if (!form.item || !form.quantity || !form.unitCost) {
+                    alert('Please select an item and enter quantity and cost.');
+                    return;
+                }
+                onSave({ ...form, total: (parseFloat(form.quantity || 0) * parseFloat(form.unitCost || 0)).toFixed(2) });
+            };
+
+            return React.createElement('div', { className: 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50' },
+                React.createElement('div', { className: 'bg-white rounded-lg shadow-xl w-full max-w-2xl p-6 space-y-4' },
+                    React.createElement('div', { className: 'flex justify-between items-center' },
+                        React.createElement('h3', { className: 'text-lg font-semibold' }, 'Add Purchase'),
+                        React.createElement('button', { onClick: onClose, className: 'text-gray-500' }, '✕')
+                    ),
+                    React.createElement('div', { className: 'grid grid-cols-1 md:grid-cols-2 gap-4' },
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Item'),
+                            React.createElement('select', {
+                                value: form.item,
+                                onChange: e => updateField('item', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'Select Item')].concat(items.map(it => React.createElement('option', { key: it.id || it.name, value: it.name || it.id }, it.name || it.id)))
+                            )
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Brand (optional)'),
+                            React.createElement('input', {
+                                type: 'text',
+                                value: form.brand,
+                                onChange: e => updateField('brand', e.target.value),
+                                className: 'w-full p-2 border rounded',
+                                placeholder: 'Brand or variant'
+                            })
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Quantity'),
+                            React.createElement('input', {
+                                type: 'number',
+                                step: '0.01',
+                                value: form.quantity,
+                                onChange: e => updateField('quantity', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            })
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Unit Cost'),
+                            React.createElement('input', {
+                                type: 'number',
+                                step: '0.01',
+                                value: form.unitCost,
+                                onChange: e => updateField('unitCost', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            })
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Supplier (optional)'),
+                            React.createElement('select', {
+                                value: form.supplier,
+                                onChange: e => updateField('supplier', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'Select Supplier')].concat(suppliers.map(sp => React.createElement('option', { key: sp.id || sp.name, value: sp.name || sp.id }, sp.name || sp.id)))
+                            )
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Invoice # (optional)'),
+                            React.createElement('input', {
+                                type: 'text',
+                                value: form.invoice,
+                                onChange: e => updateField('invoice', e.target.value),
+                                className: 'w-full p-2 border rounded',
+                                placeholder: 'Invoice number'
+                            })
+                        ),
+                        React.createElement('div', { className: 'md:col-span-2' },
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Delivery Date'),
+                            React.createElement('input', {
+                                type: 'date',
+                                value: form.date,
+                                onChange: e => updateField('date', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            })
+                        )
+                    ),
+                    React.createElement('div', { className: 'flex justify-end gap-2' },
+                        React.createElement('button', { className: 'px-4 py-2 rounded border', onClick: onClose }, 'Cancel'),
+                        React.createElement('button', { className: 'px-4 py-2 rounded bg-olive-600 text-white', onClick: handleSubmit }, 'Save Purchase')
+                    )
+                )
+            );
+        }
+
+        function PurchasesTab() {
+            const { t } = React.useContext(LanguageContext);
+            const { state } = React.useContext(AppContext);
+            const items = (state && state.data && state.data.ingredients && state.data.ingredients.length > 0) ? state.data.ingredients : [
+                { id: 'shawarma', name: 'Shawarma' },
+                { id: 'pita', name: 'Pita Bread' },
+                { id: 'lettuce', name: 'Lettuce' }
+            ];
+            const suppliers = (state && state.data && state.data.suppliers && state.data.suppliers.length > 0) ? state.data.suppliers : [
+                { id: 'supp1', name: 'Fresh Supply Co.' },
+                { id: 'supp2', name: 'Local Market' }
+            ];
+            const [filter, setFilter] = React.useState({ date: '', item: '', supplier: '' });
+            const [showModal, setShowModal] = React.useState(false);
+            const [entries, setEntries] = React.useState([
+                { id: 1, date: new Date().toISOString().split('T')[0], item: 'Shawarma', brand: 'Premium', quantity: 10, unitCost: 12, supplier: 'Fresh Supply Co.', invoice: 'INV-101', total: '120.00' },
+                { id: 2, date: new Date(Date.now() - 86400000).toISOString().split('T')[0], item: 'Pita Bread', brand: '', quantity: 50, unitCost: 0.5, supplier: 'Local Market', invoice: '', total: '25.00' }
+            ]);
+
+            const filtered = entries
+                .filter(entry => !filter.date || entry.date === filter.date)
+                .filter(entry => !filter.item || entry.item === filter.item)
+                .filter(entry => !filter.supplier || entry.supplier === filter.supplier)
+                .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+            const exportCsv = () => {
+                const headers = ['Date', 'Item', 'Brand', 'Quantity', 'Unit Cost', 'Supplier', 'Invoice', 'Total'];
+                const rows = filtered.map(e => [e.date, e.item, e.brand, e.quantity, e.unitCost, e.supplier, e.invoice, e.total]);
+                const csv = [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+                const blob = new Blob([csv], { type: 'text/csv' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'purchases.csv';
+                link.click();
+                URL.revokeObjectURL(url);
+            };
+
+            const handleSave = (entry) => {
+                setEntries(prev => [{ ...entry, id: Date.now() }, ...prev]);
+                setShowModal(false);
+            };
+
+            return React.createElement('div', { className: 'bg-white rounded-lg shadow p-6 space-y-4' },
+                React.createElement('div', { className: 'flex flex-col md:flex-row md:items-center justify-between gap-3' },
+                    React.createElement('div', { className: 'space-y-2 md:space-y-0 md:flex md:items-center md:gap-3' },
+                        React.createElement('h2', { className: 'text-xl font-semibold' }, 'Purchases'),
+                        React.createElement('div', { className: 'flex flex-wrap gap-2' },
+                            React.createElement('input', {
+                                type: 'date',
+                                value: filter.date,
+                                onChange: e => setFilter(prev => ({ ...prev, date: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            }),
+                            React.createElement('select', {
+                                value: filter.item,
+                                onChange: e => setFilter(prev => ({ ...prev, item: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'All Items')].concat(items.map(it => React.createElement('option', { key: it.id || it.name, value: it.name || it.id }, it.name || it.id)))
+                            ),
+                            React.createElement('select', {
+                                value: filter.supplier,
+                                onChange: e => setFilter(prev => ({ ...prev, supplier: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'All Suppliers')].concat(suppliers.map(sp => React.createElement('option', { key: sp.id || sp.name, value: sp.name || sp.id }, sp.name || sp.id)))
+                            )
+                        )
+                    ),
+                    React.createElement('div', { className: 'flex gap-2' },
+                        React.createElement('button', { className: 'px-4 py-2 bg-olive-600 text-white rounded', onClick: () => setShowModal(true) }, 'Add Purchase'),
+                        React.createElement('button', { className: 'px-4 py-2 border rounded', onClick: exportCsv }, 'Export CSV')
+                    )
+                ),
+                React.createElement('div', { className: 'overflow-x-auto' },
+                    React.createElement('table', { className: 'w-full text-sm border' },
+                        React.createElement('thead', { className: 'bg-gray-50' },
+                            React.createElement('tr', null,
+                                ['Date', 'Item', 'Brand', 'Qty', 'Unit Cost', 'Supplier', 'Invoice', 'Total'].map(header =>
+                                    React.createElement('th', { key: header, className: 'p-2 text-left border' }, header)
+                                )
+                            )
+                        ),
+                        React.createElement('tbody', null,
+                            filtered.map(entry => React.createElement('tr', { key: entry.id, className: 'border-b' },
+                                React.createElement('td', { className: 'p-2 border' }, entry.date),
+                                React.createElement('td', { className: 'p-2 border' }, entry.item + (entry.brand ? ` (${entry.brand})` : '')),
+                                React.createElement('td', { className: 'p-2 border' }, entry.brand || '—'),
+                                React.createElement('td', { className: 'p-2 border' }, entry.quantity),
+                                React.createElement('td', { className: 'p-2 border' }, parseFloat(entry.unitCost).toFixed(2)),
+                                React.createElement('td', { className: 'p-2 border' }, entry.supplier || '—'),
+                                React.createElement('td', { className: 'p-2 border' }, entry.invoice || '—'),
+                                React.createElement('td', { className: 'p-2 border text-right font-semibold' }, entry.total)
+                            )),
+                            filtered.length === 0 && React.createElement('tr', null,
+                                React.createElement('td', { className: 'p-3 text-center text-gray-500', colSpan: 8 }, 'No purchases found')
+                            )
+                        )
+                    )
+                ),
+                showModal && React.createElement(PurchaseFormModal, {
+                    items,
+                    suppliers,
+                    onClose: () => setShowModal(false),
+                    onSave: handleSave
+                })
+            );
+        }
+
+        function WasteEntryModal({ items, initialValue, onClose, onSave }) {
+            const [form, setForm] = React.useState(initialValue || {
+                date: new Date().toISOString().split('T')[0],
+                item: '',
+                quantity: '',
+                reason: 'Spoiled',
+                notes: ''
+            });
+
+            const selectedItem = items.find(it => (it.id || it.name) === form.item);
+            const unit = selectedItem && selectedItem.unit ? selectedItem.unit : '';
+
+            const updateField = (key, value) => setForm(prev => ({ ...prev, [key]: value }));
+
+            const handleSubmit = () => {
+                if (!form.item || !form.quantity) {
+                    alert('Please select an item and quantity.');
+                    return;
+                }
+                onSave(form);
+            };
+
+            return React.createElement('div', { className: 'fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50' },
+                React.createElement('div', { className: 'bg-white rounded-lg shadow-xl w-full max-w-lg p-6 space-y-4' },
+                    React.createElement('div', { className: 'flex justify-between items-center' },
+                        React.createElement('h3', { className: 'text-lg font-semibold' }, 'Log Waste for Today'),
+                        React.createElement('button', { onClick: onClose, className: 'text-gray-500' }, '✕')
+                    ),
+                    React.createElement('div', { className: 'space-y-3' },
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Item'),
+                            React.createElement('select', {
+                                value: form.item,
+                                onChange: e => updateField('item', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'Select Item')].concat(items.map(it => React.createElement('option', { key: it.id || it.name, value: it.id || it.name }, it.name || it.id)))
+                            )
+                        ),
+                        React.createElement('div', { className: 'grid grid-cols-1 md:grid-cols-2 gap-3' },
+                            React.createElement('div', null,
+                                React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Quantity'),
+                                React.createElement('input', {
+                                    type: 'number',
+                                    step: '0.01',
+                                    value: form.quantity,
+                                    onChange: e => updateField('quantity', e.target.value),
+                                    className: 'w-full p-2 border rounded'
+                                })
+                            ),
+                            React.createElement('div', null,
+                                React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Unit'),
+                                React.createElement('input', {
+                                    type: 'text',
+                                    value: unit || 'auto-filled',
+                                    readOnly: true,
+                                    className: 'w-full p-2 border rounded bg-gray-100'
+                                })
+                            )
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Reason'),
+                            React.createElement('select', {
+                                value: form.reason,
+                                onChange: e => updateField('reason', e.target.value),
+                                className: 'w-full p-2 border rounded'
+                            },
+                                ['Spoiled', 'Prep Error', 'Expired', 'Damaged', 'Other'].map(reason => React.createElement('option', { key: reason, value: reason }, reason))
+                            )
+                        ),
+                        React.createElement('div', null,
+                            React.createElement('label', { className: 'block text-sm font-medium mb-1' }, 'Notes (optional)'),
+                            React.createElement('textarea', {
+                                value: form.notes,
+                                onChange: e => updateField('notes', e.target.value),
+                                className: 'w-full p-2 border rounded',
+                                rows: 2
+                            })
+                        )
+                    ),
+                    React.createElement('div', { className: 'flex justify-end gap-2' },
+                        React.createElement('button', { className: 'px-4 py-2 rounded border', onClick: onClose }, 'Cancel'),
+                        React.createElement('button', { className: 'px-4 py-2 rounded bg-redbrand-600 text-white', onClick: handleSubmit }, 'Save Waste')
+                    )
+                )
+            );
+        }
+
+        function WasteLogTab({ employeeSession }) {
+            const { state } = React.useContext(AppContext);
+            const items = (state && state.data && state.data.ingredients && state.data.ingredients.length > 0) ? state.data.ingredients : [
+                { id: 'shawarma', name: 'Shawarma', unit: 'kg' },
+                { id: 'pita', name: 'Pita Bread', unit: 'pcs' },
+                { id: 'lettuce', name: 'Lettuce', unit: 'kg' }
+            ];
+            const [filter, setFilter] = React.useState({ date: '', item: '', reason: '' });
+            const [showModal, setShowModal] = React.useState(false);
+            const [editing, setEditing] = React.useState(null);
+            const [entries, setEntries] = React.useState([
+                { id: 1, date: new Date().toISOString().split('T')[0], item: 'Shawarma', quantity: 2, unit: 'kg', reason: 'Spoiled', notes: '', variance: true },
+                { id: 2, date: new Date().toISOString().split('T')[0], item: 'Pita Bread', quantity: 8, unit: 'pcs', reason: 'Prep Error', notes: '', variance: false }
+            ]);
+
+            const isManager = employeeSession && ['manager', 'admin', 'supervisor'].includes(employeeSession.employeeRole);
+
+            const filtered = entries
+                .filter(entry => !filter.date || entry.date === filter.date)
+                .filter(entry => !filter.item || entry.item === filter.item)
+                .filter(entry => !filter.reason || entry.reason === filter.reason)
+                .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+            const handleSave = (entry) => {
+                if (editing) {
+                    setEntries(prev => prev.map(e => e.id === editing.id ? { ...entry, id: editing.id, unit: entry.unit || editing.unit, variance: (parseFloat(entry.quantity || 0) > 5) } : e));
+                } else {
+                    setEntries(prev => [{ ...entry, id: Date.now(), unit: entry.unit || (items.find(it => (it.id || it.name) === entry.item)?.unit || ''), variance: (parseFloat(entry.quantity || 0) > 5) }, ...prev]);
+                }
+                setEditing(null);
+                setShowModal(false);
+            };
+
+            const handleEdit = (entry) => {
+                setEditing(entry);
+                setShowModal(true);
+            };
+
+            const handleDelete = (id) => {
+                if (confirm('Delete this waste entry?')) {
+                    setEntries(prev => prev.filter(e => e.id !== id));
+                }
+            };
+
+            return React.createElement('div', { className: 'bg-white rounded-lg shadow p-6 space-y-4' },
+                React.createElement('div', { className: 'flex flex-col md:flex-row md:items-center justify-between gap-3' },
+                    React.createElement('div', { className: 'space-y-2 md:space-y-0 md:flex md:items-center md:gap-3' },
+                        React.createElement('h2', { className: 'text-xl font-semibold' }, 'Waste Log'),
+                        React.createElement('div', { className: 'flex flex-wrap gap-2' },
+                            React.createElement('input', {
+                                type: 'date',
+                                value: filter.date,
+                                onChange: e => setFilter(prev => ({ ...prev, date: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            }),
+                            React.createElement('select', {
+                                value: filter.item,
+                                onChange: e => setFilter(prev => ({ ...prev, item: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            },
+                                [React.createElement('option', { key: '', value: '' }, 'All Items')].concat(items.map(it => React.createElement('option', { key: it.id || it.name, value: it.name || it.id }, it.name || it.id)))
+                            ),
+                            React.createElement('select', {
+                                value: filter.reason,
+                                onChange: e => setFilter(prev => ({ ...prev, reason: e.target.value })),
+                                className: 'p-2 border rounded text-sm'
+                            },
+                                ['All Reasons', 'Spoiled', 'Prep Error', 'Expired', 'Damaged', 'Other'].map(reason => React.createElement('option', { key: reason, value: reason === 'All Reasons' ? '' : reason }, reason))
+                            )
+                        )
+                    ),
+                    React.createElement('button', { className: 'px-4 py-2 bg-redbrand-600 text-white rounded', onClick: () => { setEditing(null); setShowModal(true); } }, 'Add New Waste Entry')
+                ),
+                React.createElement('div', { className: 'overflow-x-auto' },
+                    React.createElement('table', { className: 'w-full text-sm border' },
+                        React.createElement('thead', { className: 'bg-gray-50' },
+                            React.createElement('tr', null,
+                                ['Date', 'Item', 'Quantity', 'Reason', 'Variance', 'Actions'].map(header =>
+                                    React.createElement('th', { key: header, className: 'p-2 text-left border' }, header)
+                                )
+                            )
+                        ),
+                        React.createElement('tbody', null,
+                            filtered.map(entry => React.createElement('tr', { key: entry.id, className: 'border-b' },
+                                React.createElement('td', { className: 'p-2 border' }, entry.date),
+                                React.createElement('td', { className: 'p-2 border' }, entry.item),
+                                React.createElement('td', { className: 'p-2 border' }, `${entry.quantity} ${entry.unit || ''}`),
+                                React.createElement('td', { className: 'p-2 border' }, entry.reason),
+                                React.createElement('td', { className: 'p-2 border' }, entry.variance ? React.createElement('span', { className: 'px-2 py-1 text-xs rounded-full bg-yellow-100 text-yellow-700' }, 'High Loss') : '—'),
+                                React.createElement('td', { className: 'p-2 border' },
+                                    isManager ? React.createElement('div', { className: 'flex gap-2' },
+                                        React.createElement('button', { className: 'text-blue-600', onClick: () => handleEdit(entry) }, 'Edit'),
+                                        React.createElement('button', { className: 'text-red-600', onClick: () => handleDelete(entry.id) }, 'Delete')
+                                    ) : React.createElement('span', { className: 'text-gray-400' }, 'View only')
+                                )
+                            )),
+                            filtered.length === 0 && React.createElement('tr', null,
+                                React.createElement('td', { className: 'p-3 text-center text-gray-500', colSpan: 6 }, 'No waste entries found')
+                            )
+                        )
+                    )
+                ),
+                showModal && React.createElement(WasteEntryModal, {
+                    items,
+                    initialValue: editing || undefined,
+                    onClose: () => { setEditing(null); setShowModal(false); },
+                    onSave: handleSave
+                })
             );
         }
 
@@ -1394,7 +1811,13 @@ function DailyEntryTab({ employeeSession }) {
                 
             case 'inventory':
                 return React.createElement(InventoryTab);
-                
+
+            case 'purchases':
+                return React.createElement(PurchasesTab);
+
+            case 'waste_log':
+                return React.createElement(WasteLogTab, { employeeSession });
+
             case 'suppliers':
                 return React.createElement(SuppliersTab);
                 


### PR DESCRIPTION
## Summary
- add purchase entry tab with filtering, CSV export, and modal input for item, brand, supplier, quantity, and costs
- introduce waste logging modal for daily entries plus standalone waste log tab with filtering, variance indicators, and manager actions
- update navigation and daily forms to surface waste tracking summaries and quick access buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398a8bc200832598a36ec60ba1f5f7)